### PR TITLE
Add gamescope-session to the build

### DIFF
--- a/manifest
+++ b/manifest
@@ -137,6 +137,7 @@ export AUR_PACKAGES="\
 	libretro-pcsx2-git \
 	wyvern \
 	gamescope \
+	gamescope-session-git \
 	srt-live-server \
 "
 


### PR DESCRIPTION
The project already builds `gamescope` as part of the distribution and
would be nice to have a way for advanced users to test the new XWayland
compositor as a ChimerOS session. It works for most games and would
eventually be the future for Steam machines (if that ever comes to light).

The package itself it's just scripts to make it work, is 18Kb insize
and should provide the same integrations and functionality as the current
steamos-session based on steamos-compositor-plus.