### PR TITLE
Enable Kernel Modesetting for `nvidia`

### DIFF
--- a/rootfs/etc/modprobe.d/system-tweaks.conf
+++ b/rootfs/etc/modprobe.d/system-tweaks.conf
@@ -4,4 +4,5 @@ blacklist radeon
 options amdgpu si_support=1
 options amdgpu cik_support=1
 options amdgpu noretry=0
+options nvidia_drm modeset=1
 options bluetooth disable_ertm=1


### PR DESCRIPTION
This is needed for Wayland support, Prime support and some setups may benefit from it even if we don't support them.