### PR TITLE
Add nvidia-prime package

### DIFF
--- a/manifest
+++ b/manifest
@@ -59,6 +59,7 @@ export PACKAGES="\
 	lib32-opencl-nvidia \
 	nvidia-utils \
 	lib32-nvidia-utils \
+    nvidia-prime \
 	ttf-liberation \
 	wqy-zenhei \
 	openssh \


### PR DESCRIPTION
This package will allow for Nvidia optimus-like machines to offload
render workloads with minimum configuration.

With nvidia version 465 onward this can be achieved by adding a minimal
xorg configuration file (not included in current install):

/etc/X11/xorg.conf.d/10-nvidia-prime.conf
````
Section "Device"
  Identifier "iGPU"
  Driver "modesetting"
EndSection

Section "Screen"
  Identifier "iGPU"
  Device "iGPU"
EndSection

Section "Device"
  Identifier "dGPU"
  Driver "nvidia"
  BusID "PCI:<NVIDIA-PCI-ADDR>"
EndSection
````

Then test with:

$ DISPLAY :=0 prime-run glxinfo  | grep "OpenGL renderer"
$ DISPLAY :=0 prime-run vulkaninfo