### PR TITLE
Fix dkms build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,7 +206,8 @@ rm -rf \
 /extra_pkgs \
 /extra_certs \
 /home \
-/var
+/var \
+/usr/src/*
 
 rm -rf ${FILES_TO_DELETE}
 

--- a/manifest
+++ b/manifest
@@ -71,6 +71,7 @@ export PACKAGES="\
 	unzip \
 	which \
 	linux-firmware \
+	linux-headers \
 	retroarch \
 	libretro-beetle-psx \
 	libretro-beetle-psx-hw \


### PR DESCRIPTION
This pull request fixes the DKMS modules building by : 

* Adding the `linux-headers` package required by the DKMS hook of the `*-dkms` packages, which fail silently otherwise
* Cleaning up all the source files in `/usr/src/` that will not be needed on the user's system

Successfully built and deployed in my fork that I made to rollback the NVIDIA driver to 470.82.00 using the `nvidia-470-xx-*` AUR packages (not in this PR).