### PR TITLE
Add wavpack official Arch package (fix for Worms WMD)

### DIFF
--- a/manifest
+++ b/manifest
@@ -129,6 +129,7 @@ export PACKAGES="\
 	udiskie \
 	openal \
 	lib32-openal \
+	wavpack \
 	chaotic-aur/xow \
 	chaotic-aur/dolphin-emu-git \
 	chaotic-aur/dolphin-emu-nogui-git \


### PR DESCRIPTION
This PR adds the [wavpack](https://archlinux.org/packages/extra/x86_64/wavpack/files/) package from the official Arch repositories, to fix the native version of [Worms W.M.D](https://store.steampowered.com/app/327030/Worms_WMD/), which is otherwise failing to launch due to `libwavpack.so` missing.