### PR TITLE
Add libcurl-gnutls and libidn11 (fix for Worms W.M.D)

### DIFF
--- a/manifest
+++ b/manifest
@@ -130,6 +130,8 @@ export PACKAGES="\
 	openal \
 	lib32-openal \
 	wavpack \
+	libcurl-gnutls \
+	libidn11 \
 	chaotic-aur/xow \
 	chaotic-aur/dolphin-emu-git \
 	chaotic-aur/dolphin-emu-nogui-git \


### PR DESCRIPTION
This PR is a follow-up of #279 

I noticed after rebasing to ChimeraOS 28 that I forgot to add 2 packages for Worms W.M.D to work :

* [libcurl-gnutls](https://archlinux.org/packages/community/x86_64/libcurl-gnutls/)
* [libidn11](https://archlinux.org/packages/community/x86_64/libidn11/)