### PR TITLE
Create udev rule to ignore asrock led controller

### DIFF
--- a/rootfs/etc/udev/rules.d/01-asrock-LED-controller.rules
+++ b/rootfs/etc/udev/rules.d/01-asrock-LED-controller.rules
@@ -1,0 +1,2 @@
+# Disable Asrock LED controller
+ SUBSYSTEM=="usb", ATTRS{idVendor}=="26ce", ATTRS{idProduct}=="01a2", ATTR{authorized}="0"

--- a/rootfs/etc/udev/rules.d/01-asrock-LED-controller.rules
+++ b/rootfs/etc/udev/rules.d/01-asrock-LED-controller.rules
@@ -1,2 +1,6 @@
-# Disable Asrock LED controller
- SUBSYSTEM=="usb", ATTRS{idVendor}=="26ce", ATTRS{idProduct}=="01a2", ATTR{authorized}="0"
+# This rule automatically removes the Asrock led controller joystick and event interfaces from /dev/input, this does not break the ability to control rgb
+# The prevents Retroarch from detecting the led controller as a game controller
+
+SUBSYSTEM=="input", ATTRS{idVendor}=="26ce", ATTRS{idProduct}=="01a2", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="26ce", ATTRS{idProduct}=="01a2", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="26ce", ATTRS{idProduct}=="01a2", KERNEL=="event[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""


### PR DESCRIPTION
This PR creates a udev rule that ignores Asrock's motherboard rgb controller.
This is to prevent retroarch from using it as a gamepad input so me (and others) can play our retro games.