### PR TITLE
MT7921K WiFi Support for Aya Neo Pro

### DIFF
--- a/rootfs/etc/modprobe.d/rz608.conf
+++ b/rootfs/etc/modprobe.d/rz608.conf
@@ -1,0 +1,1 @@
+alias pci:v000014C3d00000608sv*sd*bc*sc*i* mt7921e

--- a/rootfs/etc/udev/rules.d/99-rz608.rules
+++ b/rootfs/etc/udev/rules.d/99-rz608.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="drivers", DEVPATH=="/bus/pci/drivers/mt7921e", ATTR{new_id}="14c3 0608"


### PR DESCRIPTION
Added modprobe and udev rules for supporting the Aya Neo Pro WiFi module in the full OS. Solves #288.