### PR TITLE
Disable Systemd handling of XF86PowerOff events #299 

### DIFF
--- a/rootfs/etc/systemd/logind.conf.d/power_off.conf
+++ b/rootfs/etc/systemd/logind.conf.d/power_off.conf
@@ -1,0 +1,2 @@
+[Login]
+HandlePowerKey=ignore

--- a/rootfs/etc/systemd/logind.conf.d/power_off.conf
+++ b/rootfs/etc/systemd/logind.conf.d/power_off.conf
@@ -1,2 +1,2 @@
 [Login]
-HandlePowerKey=ignore
+HandlePowerKey=suspend


### PR DESCRIPTION
Adds a logind.conf.d folder with a config file that ignores power button pressing. Prerequisite for https://github.com/ChimeraOS/steamos-compositor-plus/pull/48 to be enabled.