### PR TITLE
Fix kernel panic on Aya Neo 2021

### DIFF
--- a/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
+++ b/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
@@ -1,3 +1,3 @@
 #!/bin/bash
-# Unload the mt7921e driver on to avoid kernel panic on reboot.
+# Unload the mt7921e driver to avoid kernel panic on reboot.
 rmmod mt7921e

--- a/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
+++ b/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Unload the mt7921e driver on to avoid kernel panic on reboot.
+rmmod mt7921e

--- a/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
+++ b/rootfs/usr/lib/systemd/system-shutdown/mt7921e.shutdown
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Unload the mt7921e driver to avoid kernel panic on reboot.
-rmmod mt7921e
+/usr/sbin/rmmod mt7921e


### PR DESCRIPTION
Unload mt7921e driver on shutdown to prevent bug found here https://discordapp.com/channels/560281725175988233/560281725175988238/951312146963247155