### PR TITLE
Create 99-hidapi.rules for Nintendo Joy-Con and Pro Controller

### DIFF
--- a/rootfs/etc/udev/rules.d/99-hidapi.rules
+++ b/rootfs/etc/udev/rules.d/99-hidapi.rules
@@ -1,0 +1,2 @@
+#This will give read and write permissions to hidraw-devices
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", GROUP="1000", MODE="0664"


### PR DESCRIPTION
This will give read and write permissions to hidraw-devices
Such as Nintendo Joy-Con and Pro Controller