### PR TITLE
Only trigger build on commit to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: System image build
-on: push
+on:
+  push:
+    branches:
+    - 'master'
 jobs:
   build:
     name: System image build


### PR DESCRIPTION
Only trigger the image generation if a push to master. Since every other branch should not create a release and ideally would be tested locally.