### PR TITLE
Phantom Input Remover

### DIFF
--- a/manifest
+++ b/manifest
@@ -188,6 +188,7 @@ export SERVICES="\
 	systemd-timesyncd \
 	sshd \
 	neo-controller \
+	phantom-input \
 "
 
 export USER_SERVICES="\


### PR DESCRIPTION
Found a more thorough workaround for the phantom controller input. Enables service from [here](https://github.com/ShadowBlip/aya-neo-fixes/blob/main/phantom-input.service).