### PR TITLE
Remove phantom-input

### DIFF
--- a/manifest
+++ b/manifest
@@ -188,7 +188,6 @@ export SERVICES="\
 	systemd-timesyncd \
 	sshd \
 	neo-controller \
-	phantom-input \
 "
 
 export USER_SERVICES="\


### PR DESCRIPTION
Removed phantom-input from autostarting as it could cause instability in neo-controller. neo-controller.service will handle calling this service when it is ready.