### PR TITLE
Use mangohud-x11 from AUR

### DIFF
--- a/manifest
+++ b/manifest
@@ -135,6 +135,8 @@ export PACKAGES="\
 	libcurl-gnutls \
 	libidn11 \
 	liquidctl \
+	chaotic-aur/mangohud-x11 \
+	chaotic-aur/lib32-mangohud-x11 \
 	chaotic-aur/dolphin-emu-git \
 	chaotic-aur/dolphin-emu-nogui-git \
 	chaotic-aur/python-vdf \
@@ -227,10 +229,6 @@ postinstallhook() {
 
 	# avoid some broken libretro cores
 	curl -L -O https://archive.archlinux.org/repos/2022/01/09/community/os/x86_64/libretro-flycast-4475-1-x86_64.pkg.tar.zst
-
-	# get mangohud packages from Valve (current AUR package doesn't build mangoapp)
-	curl -L -O https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/lib32-mangohud-0.6.6.1.r222.gae85730-1-x86_64.pkg.tar.zst
-	curl -L -O https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/mangohud-0.6.6.1.r222.gae85730-1-x86_64.pkg.tar.zst
 
 	pacman --noconfirm -U *.pkg.tar.zst
 	rm *.pkg.tar.zst


### PR DESCRIPTION
The AUR package has been split into Wayland and X11 (XWayland) version. The `-x11` variant includes mangoapp binaries.