### PR TITLE
Don't delete include

### DIFF
--- a/manifest
+++ b/manifest
@@ -203,18 +203,15 @@ export USER_SERVICES="\
 export FILES_TO_DELETE="\
 	/boot/initramfs-linux-fallback.img \
 	/boot/syslinux \
-	/usr/include \
 	/usr/share/gtk-doc \
 	/usr/share/man \
 	/usr/share/doc \
-	/usr/share/ibus \
 	/usr/share/help \
 	/usr/share/jack-audio-connection-kit \
 	/usr/share/SFML \
 	/usr/share/libretro/autoconfig/udev/Xbox_360_Wireless_Receiver_Chinese01.cfg \
 	/usr/share/libretro/autoconfig/udev/Gasia_PS_Gamepad_USB.cfg \
 	/usr/share/libretro/autoconfig/udev/Sony-PlayStation3-DualShock3-Controller-Bluetooth.cfg \
-	/usr/src \
 "
 
 postinstallhook() {


### PR DESCRIPTION
This allows for easier development and testing on the device itself.