### PR TITLE
Make workdir a mandatory docker volume

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         run: docker build --no-cache -t image-builder:latest .
       - name: Build system image
         id: build_image
-        run: docker run --rm -v $(pwd)/output:/output --privileged=true image-builder:latest $(echo ${GITHUB_SHA} | cut -c1-7)
+        run: docker run --rm -v $(pwd):/workdir -v $(pwd)/output:/output --privileged=true image-builder:latest $(echo ${GITHUB_SHA} | cut -c1-7)
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,7 @@ To build the docker image, run the following:
 
 Then build the ChimeraOS image with the following:
 
-`docker run -it --rm -v $(pwd)/output:/output --privileged=true chimeraos-builder:latest <channel> <version>`
+`docker run -it --rm -v $(pwd):/workdir -v $(pwd)/output:/output --privileged=true chimeraos-builder:latest <channel> <version>`
 
 # Preparing for installation of the image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 
 RUN reflector --verbose --latest 20 --sort rate --save /etc/pacman.d/mirrorlist
 
 # Add the project to the container.
-ADD . /workdir
+#ADD . /workdir
 
 # Build pikaur packages as the 'build' user
 ENV BUILD_USER "build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 
 
 RUN reflector --verbose --latest 20 --sort rate --save /etc/pacman.d/mirrorlist
 
-# Add the project to the container.
-#ADD . /workdir
-
 # Build pikaur packages as the 'build' user
 ENV BUILD_USER "build"
 


### PR DESCRIPTION
Image wont build if no volume is mounted for `/workdir` thus making less likely to use wrong build files.