### PR TITLE
Add bluetooth-workaround service file

### DIFF
--- a/manifest
+++ b/manifest
@@ -183,6 +183,7 @@ export SERVICES="\
 	NetworkManager \
 	lightdm \
 	bluetooth \
+	bluetooth-workaround \
 	fstrim.timer \
 	avahi-daemon \
 	chimera-proxy.service \

--- a/rootfs/etc/systemd/system/bluetooth-workaround.service
+++ b/rootfs/etc/systemd/system/bluetooth-workaround.service
@@ -1,0 +1,10 @@
+[Unit]
+Description="Bluetooth workaround"
+
+[Service]
+Type=oneshot
+ExecStart=mkdir -p /var/lib/bluetooth
+Before=bluetooth.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Bluetooth wont start if it doesnt have `/var/lib/bluetooth` directory in
place. Since we overlay `/var` we cant deploy the directory Archlinux
worked around in their package so we add a tiny service that will just
create that directory.