### PR TITLE
Add multithread and higher compression

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -250,7 +250,7 @@ rm -rf ${BUILD_IMG}
 
 IMG_FILENAME="${SYSTEM_NAME}-${VERSION}.img.tar.xz"
 
-tar caf ${IMG_FILENAME} ${SYSTEM_NAME}-${VERSION}.img
+tar -c -I'xz -9 -T0' -f ${IMG_FILENAME} ${SYSTEM_NAME}-${VERSION}.img
 rm ${SYSTEM_NAME}-${VERSION}.img
 
 sha256sum ${SYSTEM_NAME}-${VERSION}.img.tar.xz > sha256sum.txt


### PR DESCRIPTION
Time to build reduced to an exact hour and image went to 1.87Gb to 1.75Gb on a full gnome build. 