### PR TITLE
Add xorg-xdpyinfo

### DIFF
--- a/manifest
+++ b/manifest
@@ -17,6 +17,7 @@ export PACKAGES="\
 	lightdm \
 	accountsservice \
 	xorg-server \
+	xorg-xdpyinfo \
 	bluez \
 	bluez-utils \
 	bluez-plugins \


### PR DESCRIPTION
Add `xorg-xdpyinfo` to the PACKAGES manifest so that the proposed changes to system-info (https://github.com/ChimeraOS/chimera/pull/236) closely match what Steam System Information generates.
