### PR TITLE
Do lazy unmounts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -243,8 +243,8 @@ btrfs send -f ${SYSTEM_NAME}-${VERSION}.img ${SNAP_PATH}
 cp ${BUILD_PATH}/build_info build_info.txt
 
 # clean up
-umount ${BUILD_PATH}
-umount ${MOUNT_PATH}
+umount -l ${BUILD_PATH}
+umount -l ${MOUNT_PATH}
 rm -rf ${MOUNT_PATH}
 rm -rf ${BUILD_IMG}
 


### PR DESCRIPTION
This will avoid the image failing on the last step from "resource busy". Should be safe since we are not using any binds directly.