### PR TITLE
Session switcher rework to use LightDM for all sessions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -147,16 +147,9 @@ ${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/media-support/format-media.sh*
 # set the default editor, so visudo works
 echo "export EDITOR=/usr/bin/vim" >> /etc/bash.bashrc
 
-# set default session in lightdm
-echo "
-[LightDM]
-run-directory=/run/lightdm
-logind-check-graphical=true
-[Seat:*]
-session-wrapper=/etc/lightdm/Xsession
+echo "[Seat:*]
 autologin-user=${USERNAME}
-autologin-session=steamos
-" > /etc/lightdm/lightdm.conf
+" > /etc/lightdm/lightdm.conf.d/00-autologin-user.conf
 
 echo "${SYSTEM_NAME}" > /etc/hostname
 

--- a/rootfs/etc/lightdm/lightdm.conf
+++ b/rootfs/etc/lightdm/lightdm.conf
@@ -1,0 +1,8 @@
+# Basic configuration for seat. The session should be filled in into a
+# file under /etc/lightdm/lightdm.conf.d/
+[LightDM]
+run-directory=/run/lightdm
+logind-check-graphical=true
+[Seat:*]
+session-wrapper=/etc/lightdm/Xsession
+

--- a/rootfs/etc/lightdm/lightdm.conf.d/10-chimeraos-session.conf
+++ b/rootfs/etc/lightdm/lightdm.conf.d/10-chimeraos-session.conf
@@ -1,0 +1,2 @@
+[Seat:*]
+autologin-session=steamos

--- a/rootfs/usr/bin/chimera-session
+++ b/rootfs/usr/bin/chimera-session
@@ -3,7 +3,7 @@
 DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 SESSION_CONFIG="${CONFIG_HOME}/environment.d/01-chimera-session.conf"
-LIGHTDM_CONFIG="/etc/lightdm/lightdm.conf"
+SESSION_LIGHTDM_CONFIG="/etc/lightdm/lightdm.conf.d/10-chimeraos-session.conf"
 SESSION_LIST=('bigpicture' 'desktop' 'gamepadui')
 SELECTED_SESSION="$1"
 
@@ -12,13 +12,17 @@ mkdir -p "${CONFIG_HOME}/environment.d"
 
 function print_session_list() {
 	# detect active session
-	CURRENT_SESSION="bigpicture"
-	if systemctl status gamescope@gamer &> /dev/null; then
-		CURRENT_SESSION="gamepadui"
+	CURRENT_SESSION="unknown"
+	if grep "openbox" ${SESSION_LIGHTDM_CONFIG} &> /dev/null; then
+		CURRENT_SESSION="desktop"
 	fi
 
-	if grep "openbox" ${LIGHTDM_CONFIG} &> /dev/null; then
-		CURRENT_SESSION="desktop"
+	if grep "steamos" ${SESSION_LIGHTDM_CONFIG} &> /dev/null; then
+		CURRENT_SESSION="bigpicture"
+	fi
+
+	if grep "gamescope-session" ${SESSION_LIGHTDM_CONFIG} &> /dev/null; then
+		CURRENT_SESSION="gamepadui"
 	fi
 
 	# print active and available sessions
@@ -49,9 +53,9 @@ function desktop() {
 function gamepadui() {
 	# switch to Gamepad/Deck UI (Gamescope/Wayland)
 	echo '' > ${SESSION_CONFIG}
+	sudo chimera-session-use-lightdm gamescope-session
 	systemctl --user disable sxhkd
 	systemctl --user stop sxhkd
-	sudo chimera-session-use-gamescope
 }
 
 function print_invalid_session() {

--- a/rootfs/usr/bin/chimera-session-use-gamescope
+++ b/rootfs/usr/bin/chimera-session-use-gamescope
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-systemctl disable lightdm
-systemctl stop lightdm
-systemctl enable gamescope@gamer
-systemctl restart gamescope@gamer

--- a/rootfs/usr/bin/chimera-session-use-lightdm
+++ b/rootfs/usr/bin/chimera-session-use-lightdm
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-sed -i "/autologin-session/c\autologin-session=$1" /etc/lightdm/lightdm.conf
+sed -i "/autologin-session/c\autologin-session=$1" /etc/lightdm/lightdm.conf.d/10-chimeraos-session.conf
 systemctl disable gamescope@gamer
 systemctl stop gamescope@gamer
 systemctl enable lightdm


### PR DESCRIPTION
Split LightDM configuration files into a basic configuration for all sessions, a user autologin name and a session declaration. Rework chimeraos-session-switcher to use 10-chimeraos-session.conf to change sessions. Tested on my branch and works.

Further work would need to add steamos-session-switcher to be able to work on Steam client (at leas on gamepadui) and remove some leftovers.