### PR TITLE
Add mount matrix for OXP accelerometer

### DIFF
--- a/rootfs/etc/udev/hwdb.d/61-sensor-local.hwdb
+++ b/rootfs/etc/udev/hwdb.d/61-sensor-local.hwdb
@@ -1,0 +1,6 @@
+##################
+# One X Player Mini
+##################
+sensor:modalias:acpi:BMI0160:*:dmi:*:rnONEXPLAYER:rvrV01:*
+ ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, -1
+


### PR DESCRIPTION
This will add the mount matrix of the OXP Mini AMD (and maybe others) for the accelerometer to work correctly.

The change is already merged upstream in https://github.com/systemd/systemd/pull/24158 but would be necessary until v252 of systemd hits Arch repos.