### PR TITLE
Remove bcache-tools

### DIFF
--- a/manifest
+++ b/manifest
@@ -169,7 +169,6 @@ export AUR_PACKAGES="\
 	python-inotify-simple \
 	retroarch-autoconfig-udev-git \
 	alienware-alpha-wmi \
-	bcache-tools \
 	libretro-virtualjaguar-git \
 	wyvern \
 	gamescope-plus \


### PR DESCRIPTION
We don't use it. If the image needs it, we should add it later.