### PR TITLE
Replace pulseaudio with pipewire stack

### DIFF
--- a/manifest
+++ b/manifest
@@ -40,16 +40,16 @@ export PACKAGES="\
 	networkmanager \
 	pipewire \
 	lib32-pipewire \
+	pipewire-alsa \
+	pipewire-pulse \
+	pipewire-jack \
+	gst-plugin-pipewire \
 	xdg-desktop-portal \
 	xdg-desktop-portal-wlr \
-	pulseaudio \
-	lib32-libpulse \
-	pulseaudio-alsa \
 	alsa-utils \
 	alsa-firmware \
 	sof-firmware \
 	alsa-ucm-conf \
-	pulseaudio-bluetooth \
 	sudo \
 	python \
 	flatpak \


### PR DESCRIPTION
Pipewire is stable enough now to be used. Being using it for a long time on all my setups without issues.