### PR TITLE
Introduce KERNEL_PACKAGE variable to swap kernels

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,6 +111,9 @@ Include = /etc/pacman.d/chaotic-mirrorlist
 # update package databases
 pacman --noconfirm -Syy
 
+# install kernel package
+pacman --noconfirm -S "${KERNEL_PACKAGE}" "${KERNEL_PACKAGE}-headers"
+
 # install packages
 pacman --noconfirm -S --overwrite '*' ${PACKAGES}
 rm -rf /var/cache/pacman/pkg
@@ -205,6 +208,13 @@ pacman -Q > /manifest
 # preserve installed package database
 mkdir -p /usr/var/lib/pacman
 cp -r /var/lib/pacman/local /usr/var/lib/pacman/
+
+# move kernel image and initrd to a defualt location if "linux" is not used
+if [ ${KERNEL_PACKAGE} != 'linux' ] ; then
+	mv /boot/vmlinuz-${KERNEL_PACKAGE} /boot/vmlinuz-linux
+	mv /boot/initramfs-${KERNEL_PACKAGE}.img /boot/initramfs-linux.img
+	mv /boot/initramfs-${KERNEL_PACKAGE}-fallback.img /boot/initramfs-linux-fallback.img
+fi
 
 # clean up/remove unnecessary files
 rm -rf \

--- a/manifest
+++ b/manifest
@@ -10,6 +10,8 @@ export WEBSITE="https://chimeraos.org"
 export DOCUMENTATION_URL="https://chimeraos.org/about"
 export BUG_REPORT_URL="https://github.com/ChimeraOS/chimeraos/issues"
 
+export KERNEL_PACKAGE="linux"
+
 export PACKAGES="\
 	gnome-control-center \
 	gnome-session \
@@ -71,7 +73,8 @@ export PACKAGES="\
 	lib32-libva-intel-driver \
 	xf86-video-intel \
 	intel-media-driver \
-	nvidia \
+	dkms \
+	nvidia-dkms \
 	opencl-nvidia \
 	lib32-opencl-nvidia \
 	nvidia-utils \
@@ -86,7 +89,6 @@ export PACKAGES="\
 	unzip \
 	which \
 	linux-firmware \
-	linux-headers \
 	retroarch \
 	libretro-beetle-psx \
 	libretro-beetle-psx-hw \


### PR DESCRIPTION
We dont build the kernel package because it will take too much time. Any
package we could put in that variable should be accessible via pacman
repos. Pacman configuration should be edited accordingly if non-standard
kernel is desired.