### PR TITLE
Use linux-lts to prevent bootloops on UEFI

### DIFF
--- a/manifest
+++ b/manifest
@@ -10,7 +10,7 @@ export WEBSITE="https://chimeraos.org"
 export DOCUMENTATION_URL="https://chimeraos.org/about"
 export BUG_REPORT_URL="https://github.com/ChimeraOS/chimeraos/issues"
 
-export KERNEL_PACKAGE="linux"
+export KERNEL_PACKAGE="linux-lts"
 
 export PACKAGES="\
 	gnome-control-center \


### PR DESCRIPTION
Current linux package version 5.19+ bootloops on syslinux bootloader with UEFI systems. Prevent that for now until we find a better solution.

Possible solutions would be:
- Wait for a fix in either syslinux or linux-mainline (current 6.0-rc1 also have the issue)
- Change bootloader to something else (systemd-boot could be an option if we drop BIOS support or fall back to GRUB)