### PR TITLE
Fixup: Add python-tools to fix python-smbus2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN sed -i '/ParallelDownloads/s/^#//g' /etc/pacman.conf
 
 RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.conf && \
 	pacman --noconfirm -Syyu && \
-	pacman --noconfirm -S arch-install-scripts btrfs-progs pyalpm sudo reflector python-commonmark wget xcb-util-wm fmt && \
+	pacman --noconfirm -S arch-install-scripts btrfs-progs pyalpm sudo reflector python-commonmark wget xcb-util-wm fmt python-setuptools && \
 	pacman --noconfirm -S --needed git && \
 	echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
 	useradd build -G wheel -m && \


### PR DESCRIPTION
Quick fix for build errors on python AUR packages that don't yet depend on `python-setuptools`