### PR TITLE
Remove podman-compose

### DIFF
--- a/manifest
+++ b/manifest
@@ -129,7 +129,6 @@ export PACKAGES="\
 	gamemode \
 	lib32-gamemode \
 	podman \
-	podman-compose \
 	lshw \
 	rsync \
 	dosbox \


### PR DESCRIPTION
User can install it via `pip` if needed.