### PR TITLE
Remove make, gcc and deps without deleting headers

### DIFF
--- a/manifest
+++ b/manifest
@@ -249,4 +249,7 @@ postinstallhook() {
 	yes | pacman -U steam-jupiter-stable-1.0.0.74-2.19-x86_64.pkg.tar.zst
 
 	rm *.pkg.tar.zst
+
+	# Remove build tools for slimmer image
+	pacman --noconfirm -Rnsdd make gcc
 }


### PR DESCRIPTION
This will slim the image a couple megabytes. If the suer needs to unlock and use the image for developing stuff it should install `base-devel` anyway.