### PR TITLE
Remove xf86-video-intel Xorg driver

### DIFF
--- a/manifest
+++ b/manifest
@@ -72,7 +72,6 @@ export PACKAGES="\
 	lib32-vulkan-intel \
 	libva-intel-driver \
 	lib32-libva-intel-driver \
-	xf86-video-intel \
 	intel-media-driver \
 	dkms \
 	nvidia-dkms \


### PR DESCRIPTION
Mesa is phasing out Intel driver in favor of modesetting since v20.0. We should remove it. Using modesetting is compatible with Nvidia prime configurations and iris graphics hardware.