### PR TITLE
Workaround: pygame rebuild

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,16 @@ btrfs subvolume create ${BUILD_PATH}
 # bootstrap
 pacstrap ${BUILD_PATH} base
 
+# Workaround for pygame broken by newer SDL library
+pushd /tmp
+curl -L -O https://raw.githubusercontent.com/archlinux/svntogit-community/packages/python-pygame/trunk/PKGBUILD
+if [ -n "${BUILD_USER}" ]; then
+	su "${BUILD_USER}" -c "PKGDEST=/tmp/temp_repo makepkg -s --noconfirm"
+else
+	bash -c "PKGDEST=/tmp/temp_repo makepkg -s --noconfirm"
+fi
+popd
+
 # build AUR packages to be installed later
 PIKAUR_CMD="PKGDEST=/tmp/temp_repo pikaur --noconfirm -Sw ${AUR_PACKAGES}"
 PIKAUR_RUN=(bash -c "${PIKAUR_CMD}")


### PR DESCRIPTION
This is a dirty hack to rebuild pygame and it is valid until ArchLinux maintainer rebuilds the package or the package gets updated (unknown time).