### PR TITLE
Use gamescope-plus-git

### DIFF
--- a/manifest
+++ b/manifest
@@ -152,7 +152,7 @@ export AUR_PACKAGES="\
 	alienware-alpha-wmi \
 	libretro-virtualjaguar-git \
 	wyvern \
-	gamescope-plus \
+	gamescope-plus-git \
 	gamescope-session-git \
 	r8152-dkms \
 	rtl8812au-dkms-git \


### PR DESCRIPTION
This probably will fix the Mangohud not displaying in the correct position. Seems like the non-git version uses `wlroots` from the Arch repos while -git version uses a submodue with `wlroots` with a specific commit. It doesn't affect (visibly) on regular gamescope, but since we are rotating the screen on some handhelds it most certainly affect.