### PR TITLE
Dockerfile: only use http or https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.co
 RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 version'; fi\nmkdir -p /var/cache/pikaur\n" >> /usr/bin/systemd-run && \
 	chmod +x /usr/bin/systemd-run
 
-RUN reflector --verbose --latest 20 --sort rate --save /etc/pacman.d/mirrorlist
+RUN reflector --verbose --latest 20 --protocol http,https --sort rate --save /etc/pacman.d/mirrorlist
 
 # Build pikaur packages as the 'build' user
 ENV BUILD_USER "build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist\n" >> /etc/pacman.co
 RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 version'; fi\nmkdir -p /var/cache/pikaur\n" >> /usr/bin/systemd-run && \
 	chmod +x /usr/bin/systemd-run
 
-RUN reflector --verbose --latest 20 --protocol http,https --sort rate --save /etc/pacman.d/mirrorlist
+RUN reflector --verbose --latest 20 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
 
 # Build pikaur packages as the 'build' user
 ENV BUILD_USER "build"


### PR DESCRIPTION
Since rsync is not installed within the docker-container reflector will spit errors at you. This forces reflector to use http or https.