### PR TITLE
Workaround: fatal: transport 'file' not allowed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ btrfs subvolume create ${BUILD_PATH}
 pacstrap ${BUILD_PATH} base
 
 # build AUR packages to be installed later
+export GIT_ALLOW_PROTOCOL=file:https:git
 PIKAUR_CMD="PKGDEST=/tmp/temp_repo pikaur --noconfirm -Sw ${AUR_PACKAGES}"
 PIKAUR_RUN=(bash -c "${PIKAUR_CMD}")
 if [ -n "${BUILD_USER}" ]; then


### PR DESCRIPTION
On github and locally the python-leveldb package failed to build for me. Setting this worked around the issue for me.