### PR TITLE
Update deprecated set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ jobs:
   build:
     name: System image build
     runs-on: ubuntu-20.04
+    outputs:
+      version: ${{ steps.build_image.outputs.version }}
+      display_name: ${{ steps.build_image.outputs.display_name }}
+      display_version: ${{ steps.build_image.outputs.display_version }}
+      image_filename: ${{ steps.build_image.outputs.image_filename }}
     steps:
       - uses: actions/checkout@v2
       - name: Change directory
@@ -17,7 +22,7 @@ jobs:
         run: docker build --no-cache -t image-builder:latest .
       - name: Build system image
         id: build_image
-        run: docker run --rm -v $(pwd):/workdir -v $(pwd)/output:/output --privileged=true image-builder:latest $(echo ${GITHUB_SHA} | cut -c1-7)
+        run: docker run --rm -v $(pwd):/workdir -v $(pwd)/output:/output -v $GITHUB_OUTPUT:$GITHUB_OUTPUT -e "GITHUB_OUTPUT=$GITHUB_OUTPUT" --privileged=true image-builder:latest $(echo ${GITHUB_SHA} | cut -c1-7)
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/build.sh
+++ b/build.sh
@@ -267,7 +267,11 @@ if [ -n "${OUTPUT_DIR}" ]; then
 fi
 
 # set outputs for github actions
-echo "::set-output name=version::${VERSION}"
-echo "::set-output name=display_version::${DISPLAY_VERSION}"
-echo "::set-output name=display_name::${SYSTEM_DESC}"
-echo "::set-output name=image_filename::${IMG_FILENAME}"
+if [ -f "${GITHUB_OUTPUT}" ]; then
+	echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+	echo "display_version=${DISPLAY_VERSION}" >> "${GITHUB_OUTPUT}"
+	echo "display_name=${SYSTEM_DESC}" >> "${GITHUB_OUTPUT}"
+	echo "image_filename=${IMG_FILENAME}" >> "${GITHUB_OUTPUT}"
+else
+	echo "No github output file set"
+fi


### PR DESCRIPTION
Reference: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/