### PR TITLE
Remove chaotic-aur repository

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,16 +91,6 @@ if [ -n "${ARCHIVE_DATE}" ]; then
 	' > /etc/pacman.d/mirrorlist
 fi
 
-# add chaotic-aur and copy keys into chroot
-pacman-key --recv-key FBA220DFC880C036 --keyserver keyserver.ubuntu.com
-pacman-key --lsign-key FBA220DFC880C036
-pacman --noconfirm -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-'{keyring,mirrorlist}'.pkg.tar.zst'
-
-# chaotic-aur repos
-echo '
-[chaotic-aur]
-Include = /etc/pacman.d/chaotic-mirrorlist
-' >> /etc/pacman.conf
 
 # update package databases
 pacman --noconfirm -Syy

--- a/manifest
+++ b/manifest
@@ -130,13 +130,6 @@ export PACKAGES="\
 	liquidctl \
 	dmidecode \
 	iio-sensor-proxy \
-	chaotic-aur/mangoapp \
-	chaotic-aur/libretro-stella2014-git \
-	chaotic-aur/libretro-opera-git \
-	chaotic-aur/legendary \
-	chaotic-aur/boxtron \
-	chaotic-aur/rtl88x2bu-dkms-git \
-	chaotic-aur/rtw89-dkms-git \
 "
 
 export AUR_PACKAGES="\
@@ -163,6 +156,13 @@ export AUR_PACKAGES="\
 	steam-removable-media-git \
 	rz608-fix-git \
 	handygccs-git \
+	mangoapp \
+	libretro-stella2014-git \
+	libretro-opera-git \
+	legendary \
+	boxtron \
+	rtl88x2bu-dkms-git \
+	rtw89-dkms-git \
 "
 
 export SERVICES="\


### PR DESCRIPTION
Building all packages from AUR directly doesn´t affect the build time significantly.