### PR TITLE
Remove OneXPlayer mini AMD sensor config

### DIFF
--- a/rootfs/etc/udev/hwdb.d/61-sensor-local.hwdb
+++ b/rootfs/etc/udev/hwdb.d/61-sensor-local.hwdb
@@ -1,6 +1,0 @@
-##################
-# One X Player Mini
-##################
-sensor:modalias:acpi:BMI0160:*:dmi:*:rnONEXPLAYER:rvrV01:*
- ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, -1
-


### PR DESCRIPTION
The configuration is already in current systemd v252.1