### PR TITLE
Freeze archive by date

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -222,6 +222,14 @@ echo "" >> ${BUILD_PATH}/build_info
 cat ${BUILD_PATH}/manifest >> ${BUILD_PATH}/build_info
 rm ${BUILD_PATH}/manifest
 
+# freeze archive date of build to avoid package drift on unlock
+export TODAY_DATE=$(date +%Y/%M/%d)
+echo "Server=https://archive.archlinux.org/repos/${TODAY_DATE}/\$repo/os/\$arch" > \
+${BUILD_PATH}/etc/pacman.d/mirrorlist
+
+cat ${BUILD_PATH}/etc/pacman.d/mirrorlist
+
+
 btrfs subvolume snapshot -r ${BUILD_PATH} ${SNAP_PATH}
 btrfs send -f ${SYSTEM_NAME}-${VERSION}.img ${SNAP_PATH}
 

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,13 @@ mkfs.btrfs -f ${BUILD_IMG}
 mount -t btrfs -o loop,nodatacow ${BUILD_IMG} ${MOUNT_PATH}
 btrfs subvolume create ${BUILD_PATH}
 
+# set archive date if specified
+if [ -n "${ARCHIVE_DATE}" ]; then
+	echo "
+	Server=https://archive.archlinux.org/repos/${ARCHIVE_DATE}/\$repo/os/\$arch
+	" > /etc/pacman.d/mirrorlist
+	pacman -Syyuu --noconfirm
+fi
 
 # build AUR packages to be installed later
 export GIT_ALLOW_PROTOCOL=file:https:git
@@ -83,13 +90,6 @@ pacman-key --populate
 
 echo "LANG=en_US.UTF-8" > /etc/locale.conf
 locale-gen
-
-# set archive date if specified
-if [ -n "${ARCHIVE_DATE}" ]; then
-	echo '
-	Server=https://archive.archlinux.org/repos/${ARCHIVE_DATE}/\$repo/os/\$arch
-	' > /etc/pacman.d/mirrorlist
-fi
 
 
 # update package databases
@@ -223,12 +223,12 @@ cat ${BUILD_PATH}/manifest >> ${BUILD_PATH}/build_info
 rm ${BUILD_PATH}/manifest
 
 # freeze archive date of build to avoid package drift on unlock
-export TODAY_DATE=$(date +%Y/%M/%d)
-echo "Server=https://archive.archlinux.org/repos/${TODAY_DATE}/\$repo/os/\$arch" > \
-${BUILD_PATH}/etc/pacman.d/mirrorlist
-
-cat ${BUILD_PATH}/etc/pacman.d/mirrorlist
-
+# if no archive date is set
+if [ -z "${ARCHIVE_DATE}" ]; then
+	export TODAY_DATE=$(date +%Y/%M/%d)
+	echo "Server=https://archive.archlinux.org/repos/${TODAY_DATE}/\$repo/os/\$arch" > \
+	${BUILD_PATH}/etc/pacman.d/mirrorlist
+fi
 
 btrfs subvolume snapshot -r ${BUILD_PATH} ${SNAP_PATH}
 btrfs send -f ${SYSTEM_NAME}-${VERSION}.img ${SNAP_PATH}

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ mkfs.btrfs -f ${BUILD_IMG}
 mount -t btrfs -o loop,nodatacow ${BUILD_IMG} ${MOUNT_PATH}
 btrfs subvolume create ${BUILD_PATH}
 
-# set archive date if specified
+# set archive date if specified and force update/downgrade builder
 if [ -n "${ARCHIVE_DATE}" ]; then
 	echo "
 	Server=https://archive.archlinux.org/repos/${ARCHIVE_DATE}/\$repo/os/\$arch

--- a/build.sh
+++ b/build.sh
@@ -225,7 +225,7 @@ rm ${BUILD_PATH}/manifest
 # freeze archive date of build to avoid package drift on unlock
 # if no archive date is set
 if [ -z "${ARCHIVE_DATE}" ]; then
-	export TODAY_DATE=$(date +%Y/%M/%d)
+	export TODAY_DATE=$(date +%Y/%m/%d)
 	echo "Server=https://archive.archlinux.org/repos/${TODAY_DATE}/\$repo/os/\$arch" > \
 	${BUILD_PATH}/etc/pacman.d/mirrorlist
 fi


### PR DESCRIPTION
Freeze the repositories to the build date so when unlocking the image packages like the kernel won't break.