### PR TITLE
Add udev rule for ntfs3 driver

### DIFF
--- a/rootfs/etc/udev/rules.d/00-ntfs3-default-mount.rules
+++ b/rootfs/etc/udev/rules.d/00-ntfs3-default-mount.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"


### PR DESCRIPTION
This workarounds `mount` command without a explicit type declaration. Maybe the best solution comes in modifying the script to detect NTFS and mount it with explicit type, but this works it around and doesn't seem have any downsides so far.

Reference: https://wiki.archlinux.org/title/NTFS#unknown_filesystem_type_'ntfs'