### PR TITLE
Add hhfc package

### DIFF
--- a/manifest
+++ b/manifest
@@ -159,6 +159,7 @@ export AUR_PACKAGES="\
 	rz608-fix-git \
 	handygccs-git \
 	mangoapp \
+	hhfc-git \
 	libretro-stella2014-git \
 	libretro-opera-git \
 	legendary \


### PR DESCRIPTION
The service can be enabled by the user but even then it won't start if there is no configuration file.