### PR TITLE
Build our own PKGBUILDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.SRCINFO
 *.img.tar.xz
 output/*

--- a/manifest
+++ b/manifest
@@ -133,7 +133,6 @@ export PACKAGES="\
 "
 
 export AUR_PACKAGES="\
-	chimeraos-device-quirks-git \
 	frzr \
 	steamos-compositor-plus \
 	python-vdf \

--- a/pkgs/chimeraos-device-quirks-git/PKGBUILD
+++ b/pkgs/chimeraos-device-quirks-git/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Samsagax <samsagax at gmail dot com>
+_pkgbase=chimeraos-device-quirks
+pkgname=${_pkgbase}-git
+pkgver=r3.f02d2a2
+pkgrel=1
+pkgdesc="A collection of device specific configuration files"
+arch=('any')
+url="https://github.com/ChimeraOS/device-quirks"
+license=('MIT')
+depends=('systemd')
+makedepends=('git')
+source=("${_pkgbase}::git+https://github.com/ChimeraOS/device-quirks.git")
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/${_pkgbase}"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+	cd "$srcdir/${_pkgbase}"
+	install -m644 -D -t "${pkgdir}/usr/share/licenses/${pkgname}/" LICENSE
+	install -m644 -D -t "${pkgdir}/usr/lib/modprobe.d/" usr/lib/modprobe.d/*
+	install -m644 -D -t "${pkgdir}/usr/lib/modules-load.d/" usr/lib/modules-load.d/*
+	install -m644 -D -t "${pkgdir}/usr/lib/udev/rules.d/" usr/lib/udev/rules.d/*
+}


### PR DESCRIPTION
This will make any PKGBUILD inside `pkgs` directory to be built as a package and installed in the image like all other AUR packages. This can be usefu for distro-specific packages or versions of them that need to be patched.

For now the packages are kept in our repository but eventually we can add git submodules to keep them in their own repos and even freeze them to a specific version/build (for more reproducible-ish builds).