### PR TITLE
Switch to using polkit for managing media in chimera app

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -142,6 +142,7 @@ echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/dmidecode -t 11
 echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-gamescope
 ${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-lightdm
 ${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/media-support/format-media.sh*
+${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/hwsupport/format-sdcard.sh*
 " > /etc/sudoers.d/chimera
 
 # set the default editor, so visudo works

--- a/build.sh
+++ b/build.sh
@@ -138,11 +138,9 @@ echo "${USERNAME}:${USERNAME}" | chpasswd
 # Add sudo permissions
 sed -i '/%wheel ALL=(ALL:ALL) ALL/s/^# //g' /etc/sudoers
 echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/dmidecode -t 11
-${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/hwsupport/format-sdcard.sh*
 " > /etc/sudoers.d/steam
 echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-gamescope
 ${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-lightdm
-${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/media-support/format-media.sh*
 " > /etc/sudoers.d/chimera
 
 # set the default editor, so visudo works

--- a/build.sh
+++ b/build.sh
@@ -138,11 +138,11 @@ echo "${USERNAME}:${USERNAME}" | chpasswd
 # Add sudo permissions
 sed -i '/%wheel ALL=(ALL:ALL) ALL/s/^# //g' /etc/sudoers
 echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/dmidecode -t 11
+${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/hwsupport/format-sdcard.sh*
 " > /etc/sudoers.d/steam
 echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-gamescope
 ${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/chimera-session-use-lightdm
 ${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/media-support/format-media.sh*
-${USERNAME} ALL=(ALL) NOPASSWD: /usr/lib/hwsupport/format-sdcard.sh*
 " > /etc/sudoers.d/chimera
 
 # set the default editor, so visudo works


### PR DESCRIPTION
steam-removable-media now supports formatting mmcblk0 using GamepadUI. Gives the user permission to run the script. The button is only active if an mmcblk device is detected by steam and can only format mmcblk0. The new script simply runs the old script with a hardcoded mmcblk0 parameter.