### PR TITLE
Patch Mesa 22.3.1 to fix gamescope issues for Intel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ mkdir -p /tmp/pkgs
 cp -rv pkgs/* /tmp/pkgs/.
 for package in /tmp/pkgs/*; do
 	echo "Building ${package}"
-	PIKAUR_CMD="PKGDEST=/tmp/temp_repo \
+	PIKAUR_CMD="PKGDEST=/tmp/own_pkgbuilds \
 		pikaur --noconfirm -S -P ${package}/PKGBUILD"
 	PIKAUR_RUN=(bash -c "${PIKAUR_CMD}")
 	if [ -n "${BUILD_USER}" ]; then
@@ -91,7 +91,9 @@ pacstrap -K -C rootfs/etc/pacman.conf ${BUILD_PATH}
 cp -R manifest rootfs/. ${BUILD_PATH}/
 
 mkdir ${BUILD_PATH}/extra_pkgs
+mkdir ${BUILD_PATH}/own_pkgs
 cp /tmp/temp_repo/* ${BUILD_PATH}/extra_pkgs
+cp /tmp/own_pkgbuilds/* ${BUILD_PATH}/own_pkgs
 
 # chroot into target
 mount --bind ${BUILD_PATH} ${BUILD_PATH}
@@ -113,11 +115,15 @@ pacman --noconfirm -Syy
 # install kernel package
 pacman --noconfirm -S "${KERNEL_PACKAGE}" "${KERNEL_PACKAGE}-headers"
 
+# install own override packages
+pacman --noconfirm -U --overwrite '*' /own_pkgs/*
+rm -rf /var/cache/pacman/pkg
+
 # install packages
 pacman --noconfirm -S --overwrite '*' ${PACKAGES}
 rm -rf /var/cache/pacman/pkg
 
-# install AUR & override packages
+# install AUR packages
 pacman --noconfirm -U --overwrite '*' /extra_pkgs/*
 rm -rf /var/cache/pacman/pkg
 

--- a/manifest
+++ b/manifest
@@ -59,18 +59,10 @@ export PACKAGES="\
 	flatpak \
 	vulkan-icd-loader \
 	lib32-vulkan-icd-loader \
-	libva-mesa-driver \
-	lib32-libva-mesa-driver \
-	mesa-vdpau \
 	mesa-demos \
-	lib32-mesa-vdpau \
 	libva-vdpau-driver \
 	lib32-libva-vdpau-driver \
-	vulkan-radeon \
-	lib32-vulkan-radeon \
 	xf86-video-amdgpu \
-	vulkan-intel \
-	lib32-vulkan-intel \
 	libva-intel-driver \
 	lib32-libva-intel-driver \
 	intel-media-driver \

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+Date: Sun, 12 Jun 2022 23:59:05 +0300
+Subject: [PATCH] anv: force MEDIA_INTERFACE_DESCRIPTOR_LOAD reemit after
+ 3D->GPGPU switch
+
+Seems to fix a hang in the following titles :
+   - Age of Empire 4
+   - Monster Hunter Rise
+
+where the HW is hung on a PIPE_CONTROL after a GPGPU_WALKER but no
+MEDIA_INTERFACE_DESCRIPTOR_LOAD was emitted since the switch from 3D
+to GPGPU.
+
+This would happen in the following case :
+
+   vkCmdBindPipeline(COMPUTE, cs_pipeline);
+   vkCmdDispatch(...);
+   vkCmdBindPipeline(GRAPHICS, gfx_pipeline);
+   vkCmdDraw(...);
+   vkCmdDispatch(...);
+
+Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+---
+ src/intel/vulkan/genX_cmd_buffer.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/intel/vulkan/genX_cmd_buffer.c b/src/intel/vulkan/genX_cmd_buffer.c
+index d56f9037fde1..e03dc16c1fc5 100644
+--- a/src/intel/vulkan/genX_cmd_buffer.c
++++ b/src/intel/vulkan/genX_cmd_buffer.c
+@@ -6001,6 +6001,20 @@ genX(flush_pipeline_select)(struct anv_cmd_buffer *cmd_buffer,
+    }
+ #endif
+ 
++#if GFX_VERx10 == 120
++   /* Undocumented workaround to force the re-emission of
++    * MEDIA_INTERFACE_DESCRIPTOR_LOAD when switching from 3D to Compute
++    * pipeline without rebinding a pipeline :
++    *    vkCmdBindPipeline(COMPUTE, cs_pipeline);
++    *    vkCmdDispatch(...);
++    *    vkCmdBindPipeline(GRAPHICS, gfx_pipeline);
++    *    vkCmdDraw(...);
++    *    vkCmdDispatch(...);
++    */
++   if (pipeline == _3D)
++      cmd_buffer->state.compute.pipeline_dirty = true;
++#endif
++
+    /* From "BXML » GT » MI » vol1a GPU Overview » [Instruction]
+     * PIPELINE_SELECT [DevBWR+]":
+     *

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/0001-anv-gamescope.patch
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/0001-anv-gamescope.patch
@@ -1,0 +1,394 @@
+diff --git a/src/intel/isl/isl_format.c b/src/intel/isl/isl_format.c
+index 198ecdc196ff1d17175c56ea3e0643788af5f4dc..235d2052df2b906f169eb9cedc1c71dbc4c2cc4f 100644
+--- a/src/intel/isl/isl_format.c
++++ b/src/intel/isl/isl_format.c
+@@ -966,7 +966,10 @@ isl_formats_have_same_bits_per_channel(enum isl_format format1,
+    return fmtl1->channels.r.bits == fmtl2->channels.r.bits &&
+           fmtl1->channels.g.bits == fmtl2->channels.g.bits &&
+           fmtl1->channels.b.bits == fmtl2->channels.b.bits &&
+-          fmtl1->channels.a.bits == fmtl2->channels.a.bits;
++          fmtl1->channels.a.bits == fmtl2->channels.a.bits &&
++          fmtl1->channels.l.bits == fmtl2->channels.l.bits &&
++          fmtl1->channels.i.bits == fmtl2->channels.i.bits &&
++          fmtl1->channels.p.bits == fmtl2->channels.p.bits;
+ }
+ 
+ /**
+diff --git a/src/intel/vulkan/anv_formats.c b/src/intel/vulkan/anv_formats.c
+index e361036367fc4ec6ca96779799d09ffdc9593d67..ebe7dc8d14846b3e18a2e22f19992e11e1097dec 100644
+--- a/src/intel/vulkan/anv_formats.c
++++ b/src/intel/vulkan/anv_formats.c
+@@ -989,6 +989,191 @@ void anv_GetPhysicalDeviceFormatProperties2(
+    }
+ }
+ 
++static bool
++anv_format_supports_usage(
++   VkFormatFeatureFlags2KHR format_feature_flags,
++   VkImageUsageFlags usage_flags)
++{
++   if (usage_flags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
++      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
++                                    VK_FORMAT_FEATURE_2_BLIT_SRC_BIT))) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
++      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
++                                    VK_FORMAT_FEATURE_2_BLIT_DST_BIT))) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_SAMPLED_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_STORAGE_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
++      /* Nothing to check. */
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
++      /* Ignore this flag because it was removed from the
++       * provisional_I_20150910 header.
++       */
++   }
++
++   return true;
++}
++
++static bool
++anv_formats_are_compatible(
++   const struct anv_format *img_fmt, const struct anv_format *img_view_fmt,
++   const struct intel_device_info *devinfo, VkImageTiling tiling,
++   bool allow_texel_compatible)
++{
++   if (img_view_fmt->vk_format == VK_FORMAT_UNDEFINED)
++      return false;
++
++   if (img_fmt == img_view_fmt)
++      return true;
++
++   /* TODO: Handle multi-planar images that can have view of a plane with
++    * possibly different type.
++    */
++   if (img_fmt->n_planes != 1 || img_view_fmt->n_planes != 1)
++      return false;
++
++   const enum isl_format img_isl_fmt =
++      anv_get_format_plane(devinfo, img_fmt->vk_format, 0, tiling).isl_format;
++   const enum isl_format img_view_isl_fmt =
++      anv_get_format_plane(devinfo, img_view_fmt->vk_format, 0, tiling).isl_format;
++   if (img_isl_fmt == ISL_FORMAT_UNSUPPORTED ||
++       img_view_isl_fmt == ISL_FORMAT_UNSUPPORTED)
++      return false;
++
++   const struct isl_format_layout *img_fmt_layout =
++         isl_format_get_layout(img_isl_fmt);
++   const struct isl_format_layout *img_view_fmt_layout =
++         isl_format_get_layout(img_view_isl_fmt);
++
++   /* From the Vulkan 1.3.230 spec "12.5. Image Views"
++    *
++    *    "If image was created with the
++    *    VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, format must be
++    *    compatible with the image’s format as described above; or must be
++    *    an uncompressed format, in which case it must be size-compatible
++    *    with the image’s format."
++    */
++   if (allow_texel_compatible &&
++       isl_format_is_compressed(img_isl_fmt) &&
++       !isl_format_is_compressed(img_view_isl_fmt) &&
++       img_fmt_layout->bpb == img_view_fmt_layout->bpb)
++      return true;
++
++   if (isl_format_is_compressed(img_isl_fmt) !=
++       isl_format_is_compressed(img_view_isl_fmt))
++      return false;
++
++   if (!isl_format_is_compressed(img_isl_fmt)) {
++      /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++       *
++       *    "Uncompressed color formats are compatible with each other if they
++       *    occupy the same number of bits per texel block."
++       */
++      return img_fmt_layout->bpb == img_view_fmt_layout->bpb;
++   }
++
++   /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++    *
++    *    "Compressed color formats are compatible with each other if the only
++    *    difference between them is the numerical type of the uncompressed
++    *    pixels (e.g. signed vs. unsigned, or SRGB vs. UNORM encoding)."
++    */
++   return img_fmt_layout->txc == img_view_fmt_layout->txc &&
++          isl_formats_have_same_bits_per_channel(img_isl_fmt, img_view_isl_fmt);
++}
++
++/* Returns a set of feature flags supported by any of the VkFormat listed in
++ * format_list_info or any VkFormat compatible with format.
++ */
++static VkFormatFeatureFlags2
++anv_formats_gather_format_features(
++   const struct intel_device_info *devinfo,
++   const struct anv_format *format,
++   VkImageTiling tiling,
++   const struct isl_drm_modifier_info *isl_mod_info,
++   const VkImageFormatListCreateInfo *format_list_info,
++   bool allow_texel_compatible)
++{
++   VkFormatFeatureFlags2KHR all_formats_feature_flags = 0;
++
++   /* We need to check that each of the usage bits are allowed for at least
++    * one of the potential formats.
++    */
++   if (!format_list_info || format_list_info->viewFormatCount == 0) {
++      /* If we specify no list of possible formats, we need to assume that
++       * every compatible format is possible and consider the features
++       * supported by each of them.
++       */
++      for (uint32_t fmt_arr_ind = 0;
++           fmt_arr_ind < ARRAY_SIZE(anv_formats);
++           ++fmt_arr_ind) {
++         for (uint32_t fmt_ind = 0;
++              fmt_ind < anv_formats[fmt_arr_ind].n_formats;
++              ++fmt_ind) {
++            const struct anv_format *possible_anv_format =
++               &(anv_formats[fmt_arr_ind].formats[fmt_ind]);
++
++            if (anv_formats_are_compatible(format, possible_anv_format,
++                                           devinfo, tiling,
++                                           allow_texel_compatible)) {
++               VkFormatFeatureFlags2KHR view_format_features =
++                  anv_get_image_format_features2(devinfo,
++                                                 possible_anv_format->vk_format,
++                                                 possible_anv_format, tiling,
++                                                 isl_mod_info);
++               all_formats_feature_flags |= view_format_features;
++            }
++         }
++      }
++   } else {
++      /* If we provide the list of possible formats, then check just them. */
++      for (uint32_t i = 0; i < format_list_info->viewFormatCount; ++i) {
++         VkFormat vk_view_format = format_list_info->pViewFormats[i];
++         const struct anv_format *anv_view_format =
++            anv_get_format(vk_view_format);
++         VkFormatFeatureFlags2KHR view_format_features =
++            anv_get_image_format_features2(devinfo, vk_view_format,
++                                           anv_view_format, tiling,
++                                           isl_mod_info);
++         all_formats_feature_flags |= view_format_features;
++      }
++   }
++
++   return all_formats_feature_flags;
++}
++
++
+ static VkResult
+ anv_get_image_format_properties(
+    struct anv_physical_device *physical_device,
+@@ -1021,29 +1206,6 @@ anv_get_image_format_properties(
+    }
+ 
+    assert(format->vk_format == info->format);
+-   format_feature_flags = anv_get_image_format_features2(devinfo, info->format,
+-                                                         format, info->tiling,
+-                                                         isl_mod_info);
+-
+-   /* Remove the VkFormatFeatureFlags that are incompatible with any declared
+-    * image view format. (Removals are more likely to occur when a DRM format
+-    * modifier is present).
+-    */
+-   if ((info->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) && format_list_info) {
+-      for (uint32_t i = 0; i < format_list_info->viewFormatCount; ++i) {
+-         VkFormat vk_view_format = format_list_info->pViewFormats[i];
+-         const struct anv_format *anv_view_format = anv_get_format(vk_view_format);
+-         VkFormatFeatureFlags2 view_format_features =
+-            anv_get_image_format_features2(devinfo, vk_view_format,
+-                                           anv_view_format,
+-                                           info->tiling,
+-                                           isl_mod_info);
+-         format_feature_flags &= view_format_features;
+-      }
+-   }
+-
+-   if (!format_feature_flags)
+-      goto unsupported;
+ 
+    switch (info->type) {
+    default:
+@@ -1077,21 +1239,54 @@ anv_get_image_format_properties(
+       break;
+    }
+ 
+-   /* From the Vulkan 1.2.199 spec:
++   /* From the Vulkan 1.3.218 spec:
+     *
+-    *    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT specifies that the image can be
+-    *    created with usage flags that are not supported for the format the
+-    *    image is created with but are supported for at least one format a
+-    *    VkImageView created from the image can have."
++    *    "For images created without VK_IMAGE_CREATE_EXTENDED_USAGE_BIT a usage
++    *    bit is valid if it is supported for the format the image is created with.
++    *    For images created with VK_IMAGE_CREATE_EXTENDED_USAGE_BIT a usage bit
++    *    is valid if it is supported for at least one of the formats
++    *    a VkImageView created from the image can have."
+     *
+-    * If VK_IMAGE_CREATE_EXTENDED_USAGE_BIT is set, views can be created with
+-    * different usage than the image so we can't always filter on usage.
++    *    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT specifies that the image can be
++    *    used to create a VkImageView with a different format from the image."
++    *
++    * So, if both VK_IMAGE_CREATE_EXTENDED_USAGE_BIT and
++    * VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT are set, views can be created with
++    * different usage than the image, so we can't always filter on usage.
+     * There is one exception to this below for storage.
+     */
+-   const VkImageUsageFlags image_usage = info->usage;
+-   VkImageUsageFlags view_usage = image_usage;
+-   if (info->flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT)
+-      view_usage = 0;
++   format_feature_flags = anv_get_image_format_features2(devinfo, info->format,
++                                                         format, info->tiling,
++                                                         isl_mod_info);
++
++   if (!anv_format_supports_usage(format_feature_flags, info->usage)) {
++      /* If image format itself does not support the usage, and we don't allow
++       * views formats to support it, then we can't support this usage at all.
++       */
++      if (!(info->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) ||
++          !(info->flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT))
++         goto unsupported;
++
++      /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++       *
++       *    "Each depth/stencil format is only compatible with itself."
++       *
++       * So, other formats also can't help.
++       */
++      if (vk_format_is_depth_or_stencil(info->format))
++         goto unsupported;
++
++      /* Gather all possible format feature flags for the formats listed in
++       * the format list or all the compatible formats.
++       */
++      VkFormatFeatureFlags2 all_formats_feature_flags = format_feature_flags |
++         anv_formats_gather_format_features(devinfo, format, info->tiling,
++                                            isl_mod_info, format_list_info,
++                                            info->flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
++
++      if (!anv_format_supports_usage(all_formats_feature_flags, info->usage))
++         goto unsupported;
++   }
+ 
+    if (info->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+       /* We support modifiers only for "simple" (that is, non-array
+@@ -1110,7 +1305,7 @@ anv_get_image_format_properties(
+ 
+       if (isl_mod_info->aux_usage == ISL_AUX_USAGE_CCS_E &&
+           !anv_formats_ccs_e_compatible(devinfo, info->flags, info->format,
+-                                        info->tiling, image_usage,
++                                        info->tiling, info->usage,
+                                         format_list_info)) {
+          goto unsupported;
+       }
+@@ -1132,32 +1327,12 @@ anv_get_image_format_properties(
+        (format_feature_flags & (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
+                                 VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) &&
+        !(info->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) &&
+-       !(image_usage & VK_IMAGE_USAGE_STORAGE_BIT) &&
++       !(info->usage & VK_IMAGE_USAGE_STORAGE_BIT) &&
+        isl_format_supports_multisampling(devinfo, format->planes[0].isl_format)) {
+       sampleCounts = isl_device_get_sample_counts(&physical_device->isl_dev);
+    }
+ 
+-   if (view_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
+-      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
+-                                    VK_FORMAT_FEATURE_2_BLIT_SRC_BIT))) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
+-      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
+-                                    VK_FORMAT_FEATURE_2_BLIT_DST_BIT))) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (image_usage & VK_IMAGE_USAGE_STORAGE_BIT) {
++   if (info->usage & VK_IMAGE_USAGE_STORAGE_BIT) {
+       /* Non-power-of-two formats can never be used as storage images.  We
+        * only check plane 0 because there are no YCbCr formats with
+        * non-power-of-two planes.
+@@ -1168,24 +1343,6 @@ anv_get_image_format_properties(
+          goto unsupported;
+    }
+ 
+-   if (view_usage & VK_IMAGE_USAGE_STORAGE_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+    if (info->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
+       /* From the Vulkan 1.2.149 spec, VkImageCreateInfo:
+        *
+@@ -1240,16 +1397,6 @@ anv_get_image_format_properties(
+       }
+    }
+ 
+-   if (image_usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
+-      /* Nothing to check. */
+-   }
+-
+-   if (image_usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
+-      /* Ignore this flag because it was removed from the
+-       * provisional_I_20150910 header.
+-       */
+-   }
+-
+    /* From the bspec section entitled "Surface Layout and Tiling",
+     * Gfx9 has a 256 GB limitation and Gfx11+ has a 16 TB limitation.
+     */

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/0003-d3d12-Don-t-crash-when-libd3d12.so-can-t-be-found.patch
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/0003-d3d12-Don-t-crash-when-libd3d12.so-can-t-be-found.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Sun, 4 Dec 2022 00:17:57 +0000
+Subject: [PATCH] d3d12: Don't crash when libd3d12.so can't be found
+
+`d3d12_destroy_screen` is called by `d3d12_create_dxcore_screen` after
+`d3d12_init_screen_base` fails and attempts to call `util_dl_close` on
+a NULL pointer, leading to an abort.
+
+To fix this, only close the library after if it was actually opened.
+---
+ src/gallium/drivers/d3d12/d3d12_screen.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/d3d12/d3d12_screen.cpp b/src/gallium/drivers/d3d12/d3d12_screen.cpp
+index 1cbe1fbdd5ec..c21c60e4a29c 100644
+--- a/src/gallium/drivers/d3d12/d3d12_screen.cpp
++++ b/src/gallium/drivers/d3d12/d3d12_screen.cpp
+@@ -741,7 +741,8 @@ d3d12_destroy_screen(struct d3d12_screen *screen)
+    slab_destroy_parent(&screen->transfer_pool);
+    mtx_destroy(&screen->submit_mutex);
+    mtx_destroy(&screen->descriptor_pool_mutex);
+-   util_dl_close(screen->d3d12_mod);
++   if (screen->d3d12_mod)
++      util_dl_close(screen->d3d12_mod);
+    glsl_type_singleton_decref();
+    FREE(screen);
+ }

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/LICENSE
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/LICENSE
@@ -1,0 +1,83 @@
+The Mesa 3D Graphics Library
+
+Disclaimer
+
+   Mesa is a 3-D graphics library with an API which is very similar to
+   that of [1]OpenGL.* To the extent that Mesa utilizes the OpenGL command
+   syntax or state machine, it is being used with authorization from
+   [2]Silicon Graphics, Inc.(SGI). However, the author does not possess an
+   OpenGL license from SGI, and makes no claim that Mesa is in any way a
+   compatible replacement for OpenGL or associated with SGI. Those who
+   want a licensed implementation of OpenGL should contact a licensed
+   vendor.
+
+   Please do not refer to the library as MesaGL (for legal reasons). It's
+   just Mesa or The Mesa 3-D graphics library.
+
+   * OpenGL is a trademark of [3]Silicon Graphics Incorporated.
+
+License / Copyright Information
+
+   The Mesa distribution consists of several components. Different
+   copyrights and licenses apply to different components. For example, the
+   GLX client code uses the SGI Free Software License B, and some of the
+   Mesa device drivers are copyrighted by their authors. See below for a
+   list of Mesa's main components and the license for each.
+
+   The core Mesa library is licensed according to the terms of the MIT
+   license. This allows integration with the XFree86, Xorg and DRI
+   projects.
+
+   The default Mesa license is as follows:
+
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Attention, Contributors
+
+   When contributing to the Mesa project you must agree to the licensing
+   terms of the component to which you're contributing. The following
+   section lists the primary components of the Mesa distribution and their
+   respective licenses.
+
+Mesa Component Licenses
+
+Component         Location               License
+------------------------------------------------------------------
+Main Mesa code    src/mesa/              MIT
+
+Device drivers    src/mesa/drivers/*     MIT, generally
+
+Gallium code      src/gallium/           MIT
+
+Ext headers       include/GL/glext.h     Khronos
+                  include/GL/glxext.h
+
+GLX client code   src/glx/               SGI Free Software License B
+
+C11 thread        include/c11/threads*.h Boost (permissive) emulation
+
+   In general, consult the source files for license terms.
+
+References
+
+   1. https://www.opengl.org/
+   2. https://www.sgi.com/
+   3. https://www.sgi.com/

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/PKGBUILD
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/PKGBUILD
@@ -1,0 +1,219 @@
+# Maintainer: Laurent Carlier <lordheavym@gmail.com>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Andreas Radke <andyrtr@archlinux.org>
+
+pkgbase=lib32-mesa
+pkgname=('lib32-vulkan-mesa-layers' 'lib32-opencl-mesa' 'lib32-vulkan-intel' 'lib32-vulkan-radeon' 'lib32-libva-mesa-driver' 'lib32-mesa-vdpau' 'lib32-mesa')
+pkgdesc="An open-source implementation of the OpenGL specification (32-bit)"
+pkgver=22.3.1
+pkgrel=2
+arch=('x86_64')
+makedepends=('python-mako' 'lib32-libxml2' 'lib32-expat' 'lib32-libx11' 'xorgproto' 'lib32-libdrm'
+             'lib32-libxshmfence' 'lib32-libxxf86vm' 'lib32-libxdamage' 'lib32-libvdpau'
+             'lib32-libva' 'lib32-wayland' 'wayland-protocols' 'lib32-zstd' 'lib32-libelf'
+             'lib32-llvm' 'libclc' 'clang' 'lib32-clang' 'lib32-libglvnd' 'lib32-libunwind'
+             'lib32-lm_sensors' 'lib32-libxrandr' 'lib32-vulkan-icd-loader' 'lib32-systemd'
+             'glslang' 'cmake' 'meson')
+url="https://www.mesa3d.org/"
+license=('custom')
+options=('debug' '!lto')
+source=(https://mesa.freedesktop.org/archive/mesa-${pkgver}.tar.xz
+        0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+        0001-anv-gamescope.patch
+        LICENSE)
+sha512sums=('SKIP' 'SKIP' 'SKIP' 'SKIP')
+
+prepare() {
+  cd mesa-$pkgver
+
+  # https://gitlab.freedesktop.org/mesa/mesa/-/issues/7111
+  # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/17247
+  # https://github.com/HansKristian-Work/vkd3d-proton/issues/1200
+  patch -Np1 -i ../0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+  patch -Np1 -i ../0001-anv-gamescope.patch
+}
+
+build() {
+  # Build only minimal debug info to reduce size
+  CFLAGS+=' -g1'
+  CXXFLAGS+=' -g1'
+
+  export CC="gcc -m32"
+  export CXX="g++ -m32"
+  export PKG_CONFIG="i686-pc-linux-gnu-pkg-config"
+  cat >crossfile.ini <<END
+[binaries]
+llvm-config = '/usr/bin/llvm-config32'
+END
+
+  # swr driver is broken with some cpu see FS#66972
+
+  arch-meson mesa-$pkgver build \
+    --native-file crossfile.ini \
+    --libdir=/usr/lib32 \
+    -D b_ndebug=true \
+    -D b_lto=false \
+    -D platforms=x11,wayland \
+    -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink \
+    -D vulkan-drivers=amd,intel,intel_hasvk \
+    -D vulkan-layers=device-select,intel-nullhw,overlay \
+    -D dri3=enabled \
+    -D egl=enabled \
+    -D gallium-extra-hud=true \
+    -D gallium-nine=true \
+    -D gallium-omx=disabled \
+    -D gallium-opencl=icd \
+    -D gallium-va=enabled \
+    -D gallium-vdpau=enabled \
+    -D gallium-xa=enabled \
+    -D gbm=enabled \
+    -D gles1=disabled \
+    -D gles2=enabled \
+    -D glvnd=true \
+    -D glx=dri \
+    -D libunwind=enabled \
+    -D llvm=enabled \
+    -D lmsensors=enabled \
+    -D osmesa=true \
+    -D shared-glapi=enabled \
+    -D microsoft-clc=disabled \
+    -D video-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
+    -D valgrind=disabled
+
+  # Print config
+  meson configure --no-pager build
+
+  ninja -C build
+  meson compile -C build
+
+  # fake installation to be seperated into packages
+  # outside of fakeroot but mesa doesn't need to chown/mod
+  DESTDIR="${srcdir}/fakeinstall" meson install -C build
+}
+
+_install() {
+  local src f dir
+  for src; do
+    f="${src#fakeinstall/}"
+    dir="${pkgdir}/${f%/*}"
+    install -m755 -d "${dir}"
+    mv -v "${src}" "${dir}/"
+  done
+}
+
+package_lib32-vulkan-mesa-layers() {
+  pkgdesc="Mesa's Vulkan layers (32-bit)"
+  depends=('lib32-libdrm' 'lib32-libxcb' 'lib32-wayland' 'vulkan-mesa-layers')
+  conflicts=('lib32-vulkan-mesa-layer')
+  replaces=('lib32-vulkan-mesa-layer')
+
+  rm -rv fakeinstall/usr/share/vulkan/explicit_layer.d
+  rm -rv fakeinstall/usr/share/vulkan/implicit_layer.d
+  rm -rv fakeinstall/usr/bin/mesa-overlay-control.py
+
+  _install fakeinstall/usr/lib32/libVkLayer_*.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-opencl-mesa() {
+  pkgdesc="OpenCL support for AMD/ATI Radeon mesa drivers (32-bit)"
+  depends=('lib32-expat' 'lib32-libdrm' 'lib32-libelf' 'lib32-clang' 'lib32-zstd' 'opencl-mesa')
+  optdepends=('opencl-headers: headers necessary for OpenCL development')
+  provides=('lib32-opencl-driver')
+
+  rm -rv fakeinstall/etc/OpenCL
+  _install fakeinstall/usr/lib32/lib*OpenCL*
+  _install fakeinstall/usr/lib32/gallium-pipe
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-vulkan-intel() {
+  pkgdesc="Intel's Vulkan mesa driver (32-bit)"
+  depends=('lib32-wayland' 'lib32-libx11' 'lib32-libxshmfence' 'lib32-libdrm' 'lib32-zstd'
+           'lib32-systemd')
+  optdepends=('lib32-vulkan-mesa-layers: additional vulkan layers')
+  provides=('lib32-vulkan-driver')
+
+  _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
+  _install fakeinstall/usr/lib32/libvulkan_intel*.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-vulkan-radeon() {
+  pkgdesc="Radeon's Vulkan mesa driver (32-bit)"
+  depends=('lib32-wayland' 'lib32-libx11' 'lib32-libxshmfence' 'lib32-libelf' 'lib32-libdrm'
+           'lib32-zstd' 'lib32-llvm-libs' 'lib32-systemd')
+  optdepends=('lib32-vulkan-mesa-layers: additional vulkan layers')
+  provides=('lib32-vulkan-driver')
+
+  _install fakeinstall/usr/share/vulkan/icd.d/radeon_icd*.json
+  _install fakeinstall/usr/lib32/libvulkan_radeon.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-libva-mesa-driver() {
+  pkgdesc="VA-API implementation for gallium (32-bit)"
+  depends=('lib32-libdrm' 'lib32-libx11' 'lib32-llvm-libs' 'lib32-expat' 'lib32-libelf'
+           'lib32-libxshmfence' 'lib32-zstd')
+
+  _install fakeinstall/usr/lib32/dri/*_drv_video.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-mesa-vdpau() {
+  pkgdesc="Mesa VDPAU drivers (32-bit)"
+  depends=('lib32-libdrm' 'lib32-libx11' 'lib32-llvm-libs' 'lib32-expat' 'lib32-libelf'
+           'lib32-libxshmfence' 'lib32-zstd')
+
+  _install fakeinstall/usr/lib32/vdpau
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_lib32-mesa() {
+  depends=('lib32-libdrm' 'lib32-wayland' 'lib32-libxxf86vm' 'lib32-libxdamage' 'lib32-libxshmfence'
+           'lib32-libelf' 'lib32-libunwind' 'lib32-llvm-libs' 'lib32-lm_sensors' 'lib32-libglvnd'
+           'lib32-zstd' 'lib32-vulkan-icd-loader' 'mesa')
+  depends+=('libsensors.so')
+  optdepends=('opengl-man-pages: for the OpenGL API man pages'
+              'lib32-mesa-vdpau: for accelerated video playback'
+              'lib32-libva-mesa-driver: for accelerated video playback')
+  provides=('lib32-mesa-libgl' 'lib32-opengl-driver')
+  conflicts=('lib32-mesa-libgl')
+  replaces=('lib32-mesa-libgl')
+
+  rm -rv fakeinstall/usr/share/drirc.d/00-mesa-defaults.conf
+  rm -rv fakeinstall/usr/share/drirc.d/00-radv-defaults.conf
+  rm -rv fakeinstall/usr/share/glvnd/egl_vendor.d/50_mesa.json
+
+  # ati-dri, nouveau-dri, intel-dri, svga-dri, swrast, swr
+  _install fakeinstall/usr/lib32/dri/*_dri.so
+
+  #_install fakeinstall/usr/lib32/bellagio
+  _install fakeinstall/usr/lib32/d3d
+  _install fakeinstall/usr/lib32/lib{gbm,glapi}.so*
+  _install fakeinstall/usr/lib32/libOSMesa.so*
+  _install fakeinstall/usr/lib32/libxatracker.so*
+  #_install fakeinstall/usr/lib32/libswrAVX*.so*
+
+  rm -rv fakeinstall/usr/include
+  _install fakeinstall/usr/lib32/pkgconfig
+
+  # libglvnd support
+  _install fakeinstall/usr/lib32/libGLX_mesa.so*
+  _install fakeinstall/usr/lib32/libEGL_mesa.so*
+
+  # indirect rendering
+  ln -s /usr/lib32/libGLX_mesa.so.0 "${pkgdir}/usr/lib32/libGLX_indirect.so.0"
+
+  # make sure there are no files left to install
+  find fakeinstall -depth -print0 | xargs -0 rmdir
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}

--- a/pkgs/lib32-mesa-22.3.1-anv-patch/PKGBUILD
+++ b/pkgs/lib32-mesa-22.3.1-anv-patch/PKGBUILD
@@ -3,11 +3,16 @@
 # Contributor: Jan de Groot <jgc@archlinux.org>
 # Contributor: Andreas Radke <andyrtr@archlinux.org>
 
-pkgbase=lib32-mesa
-pkgname=('lib32-vulkan-mesa-layers' 'lib32-opencl-mesa' 'lib32-vulkan-intel' 'lib32-vulkan-radeon' 'lib32-libva-mesa-driver' 'lib32-mesa-vdpau' 'lib32-mesa')
-pkgdesc="An open-source implementation of the OpenGL specification (32-bit)"
+pkgbase=lib32-mesa-anv-patch
+pkgname=('lib32-vulkan-mesa-layers-anv-patch'
+				 'lib32-vulkan-intel-anv-patch'
+				 'lib32-vulkan-radeon-anv-patch'
+				 'lib32-libva-mesa-driver-anv-patch'
+				 'lib32-mesa-vdpau-anv-patch'
+				 'lib32-mesa-anv-patch')
+pkgdesc="An open-source implementation of the OpenGL specification (32-bit) - ANV patch for gamescope"
 pkgver=22.3.1
-pkgrel=2
+pkgrel=1
 arch=('x86_64')
 makedepends=('python-mako' 'lib32-libxml2' 'lib32-expat' 'lib32-libx11' 'xorgproto' 'lib32-libdrm'
              'lib32-libxshmfence' 'lib32-libxxf86vm' 'lib32-libxdamage' 'lib32-libvdpau'
@@ -63,7 +68,7 @@ END
     -D gallium-extra-hud=true \
     -D gallium-nine=true \
     -D gallium-omx=disabled \
-    -D gallium-opencl=icd \
+    -D gallium-opencl=disabled \
     -D gallium-va=enabled \
     -D gallium-vdpau=enabled \
     -D gallium-xa=enabled \
@@ -102,11 +107,12 @@ _install() {
   done
 }
 
-package_lib32-vulkan-mesa-layers() {
+package_lib32-vulkan-mesa-layers-anv-patch() {
   pkgdesc="Mesa's Vulkan layers (32-bit)"
   depends=('lib32-libdrm' 'lib32-libxcb' 'lib32-wayland' 'vulkan-mesa-layers')
-  conflicts=('lib32-vulkan-mesa-layer')
+  conflicts=('lib32-vulkan-mesa-layers' 'lib32-vulkan-mesa-layer')
   replaces=('lib32-vulkan-mesa-layer')
+	provides=('lib32-vulkan-mesa-layers')
 
   rm -rv fakeinstall/usr/share/vulkan/explicit_layer.d
   rm -rv fakeinstall/usr/share/vulkan/implicit_layer.d
@@ -117,25 +123,13 @@ package_lib32-vulkan-mesa-layers() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_lib32-opencl-mesa() {
-  pkgdesc="OpenCL support for AMD/ATI Radeon mesa drivers (32-bit)"
-  depends=('lib32-expat' 'lib32-libdrm' 'lib32-libelf' 'lib32-clang' 'lib32-zstd' 'opencl-mesa')
-  optdepends=('opencl-headers: headers necessary for OpenCL development')
-  provides=('lib32-opencl-driver')
-
-  rm -rv fakeinstall/etc/OpenCL
-  _install fakeinstall/usr/lib32/lib*OpenCL*
-  _install fakeinstall/usr/lib32/gallium-pipe
-
-  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
-}
-
-package_lib32-vulkan-intel() {
+package_lib32-vulkan-intel-anv-patch() {
   pkgdesc="Intel's Vulkan mesa driver (32-bit)"
   depends=('lib32-wayland' 'lib32-libx11' 'lib32-libxshmfence' 'lib32-libdrm' 'lib32-zstd'
            'lib32-systemd')
   optdepends=('lib32-vulkan-mesa-layers: additional vulkan layers')
-  provides=('lib32-vulkan-driver')
+  provides=('lib32-vulkan-intel' 'lib32-vulkan-driver')
+  conflicts=('lib32-vulkan-intel')
 
   _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
   _install fakeinstall/usr/lib32/libvulkan_intel*.so
@@ -143,12 +137,13 @@ package_lib32-vulkan-intel() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_lib32-vulkan-radeon() {
+package_lib32-vulkan-radeon-anv-patch() {
   pkgdesc="Radeon's Vulkan mesa driver (32-bit)"
   depends=('lib32-wayland' 'lib32-libx11' 'lib32-libxshmfence' 'lib32-libelf' 'lib32-libdrm'
            'lib32-zstd' 'lib32-llvm-libs' 'lib32-systemd')
   optdepends=('lib32-vulkan-mesa-layers: additional vulkan layers')
-  provides=('lib32-vulkan-driver')
+  provides=('lib32-vulkan-radeon' 'lib32-vulkan-driver')
+  conflicts=('lib32-vulkan-radeon')
 
   _install fakeinstall/usr/share/vulkan/icd.d/radeon_icd*.json
   _install fakeinstall/usr/lib32/libvulkan_radeon.so
@@ -156,27 +151,31 @@ package_lib32-vulkan-radeon() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_lib32-libva-mesa-driver() {
+package_lib32-libva-mesa-driver-anv-patch() {
   pkgdesc="VA-API implementation for gallium (32-bit)"
   depends=('lib32-libdrm' 'lib32-libx11' 'lib32-llvm-libs' 'lib32-expat' 'lib32-libelf'
            'lib32-libxshmfence' 'lib32-zstd')
+	provides=('lib32-libva-mesa-driver')
+	conflicts=('lib32-libva-mesa-driver')
 
   _install fakeinstall/usr/lib32/dri/*_drv_video.so
 
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_lib32-mesa-vdpau() {
+package_lib32-mesa-vdpau-anv-patch() {
   pkgdesc="Mesa VDPAU drivers (32-bit)"
   depends=('lib32-libdrm' 'lib32-libx11' 'lib32-llvm-libs' 'lib32-expat' 'lib32-libelf'
            'lib32-libxshmfence' 'lib32-zstd')
+	provides=('lib32-mesa-vdpau')
+	conflicts=('lib32-mesa-vdpau')
 
   _install fakeinstall/usr/lib32/vdpau
 
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_lib32-mesa() {
+package_lib32-mesa-anv-patch() {
   depends=('lib32-libdrm' 'lib32-wayland' 'lib32-libxxf86vm' 'lib32-libxdamage' 'lib32-libxshmfence'
            'lib32-libelf' 'lib32-libunwind' 'lib32-llvm-libs' 'lib32-lm_sensors' 'lib32-libglvnd'
            'lib32-zstd' 'lib32-vulkan-icd-loader' 'mesa')
@@ -184,8 +183,8 @@ package_lib32-mesa() {
   optdepends=('opengl-man-pages: for the OpenGL API man pages'
               'lib32-mesa-vdpau: for accelerated video playback'
               'lib32-libva-mesa-driver: for accelerated video playback')
-  provides=('lib32-mesa-libgl' 'lib32-opengl-driver')
-  conflicts=('lib32-mesa-libgl')
+  provides=('lib32-mesa' 'lib32-mesa-libgl' 'lib32-opengl-driver')
+  conflicts=('lib32-mesa' 'lib32-mesa-libgl')
   replaces=('lib32-mesa-libgl')
 
   rm -rv fakeinstall/usr/share/drirc.d/00-mesa-defaults.conf

--- a/pkgs/mesa-22.3.1-anv-patch/0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+++ b/pkgs/mesa-22.3.1-anv-patch/0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+Date: Sun, 12 Jun 2022 23:59:05 +0300
+Subject: [PATCH] anv: force MEDIA_INTERFACE_DESCRIPTOR_LOAD reemit after
+ 3D->GPGPU switch
+
+Seems to fix a hang in the following titles :
+   - Age of Empire 4
+   - Monster Hunter Rise
+
+where the HW is hung on a PIPE_CONTROL after a GPGPU_WALKER but no
+MEDIA_INTERFACE_DESCRIPTOR_LOAD was emitted since the switch from 3D
+to GPGPU.
+
+This would happen in the following case :
+
+   vkCmdBindPipeline(COMPUTE, cs_pipeline);
+   vkCmdDispatch(...);
+   vkCmdBindPipeline(GRAPHICS, gfx_pipeline);
+   vkCmdDraw(...);
+   vkCmdDispatch(...);
+
+Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+---
+ src/intel/vulkan/genX_cmd_buffer.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/intel/vulkan/genX_cmd_buffer.c b/src/intel/vulkan/genX_cmd_buffer.c
+index d56f9037fde1..e03dc16c1fc5 100644
+--- a/src/intel/vulkan/genX_cmd_buffer.c
++++ b/src/intel/vulkan/genX_cmd_buffer.c
+@@ -6001,6 +6001,20 @@ genX(flush_pipeline_select)(struct anv_cmd_buffer *cmd_buffer,
+    }
+ #endif
+ 
++#if GFX_VERx10 == 120
++   /* Undocumented workaround to force the re-emission of
++    * MEDIA_INTERFACE_DESCRIPTOR_LOAD when switching from 3D to Compute
++    * pipeline without rebinding a pipeline :
++    *    vkCmdBindPipeline(COMPUTE, cs_pipeline);
++    *    vkCmdDispatch(...);
++    *    vkCmdBindPipeline(GRAPHICS, gfx_pipeline);
++    *    vkCmdDraw(...);
++    *    vkCmdDispatch(...);
++    */
++   if (pipeline == _3D)
++      cmd_buffer->state.compute.pipeline_dirty = true;
++#endif
++
+    /* From "BXML » GT » MI » vol1a GPU Overview » [Instruction]
+     * PIPELINE_SELECT [DevBWR+]":
+     *

--- a/pkgs/mesa-22.3.1-anv-patch/0001-anv-gamescope.patch
+++ b/pkgs/mesa-22.3.1-anv-patch/0001-anv-gamescope.patch
@@ -1,0 +1,394 @@
+diff --git a/src/intel/isl/isl_format.c b/src/intel/isl/isl_format.c
+index 198ecdc196ff1d17175c56ea3e0643788af5f4dc..235d2052df2b906f169eb9cedc1c71dbc4c2cc4f 100644
+--- a/src/intel/isl/isl_format.c
++++ b/src/intel/isl/isl_format.c
+@@ -966,7 +966,10 @@ isl_formats_have_same_bits_per_channel(enum isl_format format1,
+    return fmtl1->channels.r.bits == fmtl2->channels.r.bits &&
+           fmtl1->channels.g.bits == fmtl2->channels.g.bits &&
+           fmtl1->channels.b.bits == fmtl2->channels.b.bits &&
+-          fmtl1->channels.a.bits == fmtl2->channels.a.bits;
++          fmtl1->channels.a.bits == fmtl2->channels.a.bits &&
++          fmtl1->channels.l.bits == fmtl2->channels.l.bits &&
++          fmtl1->channels.i.bits == fmtl2->channels.i.bits &&
++          fmtl1->channels.p.bits == fmtl2->channels.p.bits;
+ }
+ 
+ /**
+diff --git a/src/intel/vulkan/anv_formats.c b/src/intel/vulkan/anv_formats.c
+index e361036367fc4ec6ca96779799d09ffdc9593d67..ebe7dc8d14846b3e18a2e22f19992e11e1097dec 100644
+--- a/src/intel/vulkan/anv_formats.c
++++ b/src/intel/vulkan/anv_formats.c
+@@ -989,6 +989,191 @@ void anv_GetPhysicalDeviceFormatProperties2(
+    }
+ }
+ 
++static bool
++anv_format_supports_usage(
++   VkFormatFeatureFlags2KHR format_feature_flags,
++   VkImageUsageFlags usage_flags)
++{
++   if (usage_flags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
++      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
++                                    VK_FORMAT_FEATURE_2_BLIT_SRC_BIT))) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
++      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
++                                    VK_FORMAT_FEATURE_2_BLIT_DST_BIT))) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_SAMPLED_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_STORAGE_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
++      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) {
++         return false;
++      }
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
++      /* Nothing to check. */
++   }
++
++   if (usage_flags & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
++      /* Ignore this flag because it was removed from the
++       * provisional_I_20150910 header.
++       */
++   }
++
++   return true;
++}
++
++static bool
++anv_formats_are_compatible(
++   const struct anv_format *img_fmt, const struct anv_format *img_view_fmt,
++   const struct intel_device_info *devinfo, VkImageTiling tiling,
++   bool allow_texel_compatible)
++{
++   if (img_view_fmt->vk_format == VK_FORMAT_UNDEFINED)
++      return false;
++
++   if (img_fmt == img_view_fmt)
++      return true;
++
++   /* TODO: Handle multi-planar images that can have view of a plane with
++    * possibly different type.
++    */
++   if (img_fmt->n_planes != 1 || img_view_fmt->n_planes != 1)
++      return false;
++
++   const enum isl_format img_isl_fmt =
++      anv_get_format_plane(devinfo, img_fmt->vk_format, 0, tiling).isl_format;
++   const enum isl_format img_view_isl_fmt =
++      anv_get_format_plane(devinfo, img_view_fmt->vk_format, 0, tiling).isl_format;
++   if (img_isl_fmt == ISL_FORMAT_UNSUPPORTED ||
++       img_view_isl_fmt == ISL_FORMAT_UNSUPPORTED)
++      return false;
++
++   const struct isl_format_layout *img_fmt_layout =
++         isl_format_get_layout(img_isl_fmt);
++   const struct isl_format_layout *img_view_fmt_layout =
++         isl_format_get_layout(img_view_isl_fmt);
++
++   /* From the Vulkan 1.3.230 spec "12.5. Image Views"
++    *
++    *    "If image was created with the
++    *    VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, format must be
++    *    compatible with the image’s format as described above; or must be
++    *    an uncompressed format, in which case it must be size-compatible
++    *    with the image’s format."
++    */
++   if (allow_texel_compatible &&
++       isl_format_is_compressed(img_isl_fmt) &&
++       !isl_format_is_compressed(img_view_isl_fmt) &&
++       img_fmt_layout->bpb == img_view_fmt_layout->bpb)
++      return true;
++
++   if (isl_format_is_compressed(img_isl_fmt) !=
++       isl_format_is_compressed(img_view_isl_fmt))
++      return false;
++
++   if (!isl_format_is_compressed(img_isl_fmt)) {
++      /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++       *
++       *    "Uncompressed color formats are compatible with each other if they
++       *    occupy the same number of bits per texel block."
++       */
++      return img_fmt_layout->bpb == img_view_fmt_layout->bpb;
++   }
++
++   /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++    *
++    *    "Compressed color formats are compatible with each other if the only
++    *    difference between them is the numerical type of the uncompressed
++    *    pixels (e.g. signed vs. unsigned, or SRGB vs. UNORM encoding)."
++    */
++   return img_fmt_layout->txc == img_view_fmt_layout->txc &&
++          isl_formats_have_same_bits_per_channel(img_isl_fmt, img_view_isl_fmt);
++}
++
++/* Returns a set of feature flags supported by any of the VkFormat listed in
++ * format_list_info or any VkFormat compatible with format.
++ */
++static VkFormatFeatureFlags2
++anv_formats_gather_format_features(
++   const struct intel_device_info *devinfo,
++   const struct anv_format *format,
++   VkImageTiling tiling,
++   const struct isl_drm_modifier_info *isl_mod_info,
++   const VkImageFormatListCreateInfo *format_list_info,
++   bool allow_texel_compatible)
++{
++   VkFormatFeatureFlags2KHR all_formats_feature_flags = 0;
++
++   /* We need to check that each of the usage bits are allowed for at least
++    * one of the potential formats.
++    */
++   if (!format_list_info || format_list_info->viewFormatCount == 0) {
++      /* If we specify no list of possible formats, we need to assume that
++       * every compatible format is possible and consider the features
++       * supported by each of them.
++       */
++      for (uint32_t fmt_arr_ind = 0;
++           fmt_arr_ind < ARRAY_SIZE(anv_formats);
++           ++fmt_arr_ind) {
++         for (uint32_t fmt_ind = 0;
++              fmt_ind < anv_formats[fmt_arr_ind].n_formats;
++              ++fmt_ind) {
++            const struct anv_format *possible_anv_format =
++               &(anv_formats[fmt_arr_ind].formats[fmt_ind]);
++
++            if (anv_formats_are_compatible(format, possible_anv_format,
++                                           devinfo, tiling,
++                                           allow_texel_compatible)) {
++               VkFormatFeatureFlags2KHR view_format_features =
++                  anv_get_image_format_features2(devinfo,
++                                                 possible_anv_format->vk_format,
++                                                 possible_anv_format, tiling,
++                                                 isl_mod_info);
++               all_formats_feature_flags |= view_format_features;
++            }
++         }
++      }
++   } else {
++      /* If we provide the list of possible formats, then check just them. */
++      for (uint32_t i = 0; i < format_list_info->viewFormatCount; ++i) {
++         VkFormat vk_view_format = format_list_info->pViewFormats[i];
++         const struct anv_format *anv_view_format =
++            anv_get_format(vk_view_format);
++         VkFormatFeatureFlags2KHR view_format_features =
++            anv_get_image_format_features2(devinfo, vk_view_format,
++                                           anv_view_format, tiling,
++                                           isl_mod_info);
++         all_formats_feature_flags |= view_format_features;
++      }
++   }
++
++   return all_formats_feature_flags;
++}
++
++
+ static VkResult
+ anv_get_image_format_properties(
+    struct anv_physical_device *physical_device,
+@@ -1021,29 +1206,6 @@ anv_get_image_format_properties(
+    }
+ 
+    assert(format->vk_format == info->format);
+-   format_feature_flags = anv_get_image_format_features2(devinfo, info->format,
+-                                                         format, info->tiling,
+-                                                         isl_mod_info);
+-
+-   /* Remove the VkFormatFeatureFlags that are incompatible with any declared
+-    * image view format. (Removals are more likely to occur when a DRM format
+-    * modifier is present).
+-    */
+-   if ((info->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) && format_list_info) {
+-      for (uint32_t i = 0; i < format_list_info->viewFormatCount; ++i) {
+-         VkFormat vk_view_format = format_list_info->pViewFormats[i];
+-         const struct anv_format *anv_view_format = anv_get_format(vk_view_format);
+-         VkFormatFeatureFlags2 view_format_features =
+-            anv_get_image_format_features2(devinfo, vk_view_format,
+-                                           anv_view_format,
+-                                           info->tiling,
+-                                           isl_mod_info);
+-         format_feature_flags &= view_format_features;
+-      }
+-   }
+-
+-   if (!format_feature_flags)
+-      goto unsupported;
+ 
+    switch (info->type) {
+    default:
+@@ -1077,21 +1239,54 @@ anv_get_image_format_properties(
+       break;
+    }
+ 
+-   /* From the Vulkan 1.2.199 spec:
++   /* From the Vulkan 1.3.218 spec:
+     *
+-    *    "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT specifies that the image can be
+-    *    created with usage flags that are not supported for the format the
+-    *    image is created with but are supported for at least one format a
+-    *    VkImageView created from the image can have."
++    *    "For images created without VK_IMAGE_CREATE_EXTENDED_USAGE_BIT a usage
++    *    bit is valid if it is supported for the format the image is created with.
++    *    For images created with VK_IMAGE_CREATE_EXTENDED_USAGE_BIT a usage bit
++    *    is valid if it is supported for at least one of the formats
++    *    a VkImageView created from the image can have."
+     *
+-    * If VK_IMAGE_CREATE_EXTENDED_USAGE_BIT is set, views can be created with
+-    * different usage than the image so we can't always filter on usage.
++    *    "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT specifies that the image can be
++    *    used to create a VkImageView with a different format from the image."
++    *
++    * So, if both VK_IMAGE_CREATE_EXTENDED_USAGE_BIT and
++    * VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT are set, views can be created with
++    * different usage than the image, so we can't always filter on usage.
+     * There is one exception to this below for storage.
+     */
+-   const VkImageUsageFlags image_usage = info->usage;
+-   VkImageUsageFlags view_usage = image_usage;
+-   if (info->flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT)
+-      view_usage = 0;
++   format_feature_flags = anv_get_image_format_features2(devinfo, info->format,
++                                                         format, info->tiling,
++                                                         isl_mod_info);
++
++   if (!anv_format_supports_usage(format_feature_flags, info->usage)) {
++      /* If image format itself does not support the usage, and we don't allow
++       * views formats to support it, then we can't support this usage at all.
++       */
++      if (!(info->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) ||
++          !(info->flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT))
++         goto unsupported;
++
++      /* From the Vulkan 1.3.224 spec "43.1.6. Format Compatibility Classes":
++       *
++       *    "Each depth/stencil format is only compatible with itself."
++       *
++       * So, other formats also can't help.
++       */
++      if (vk_format_is_depth_or_stencil(info->format))
++         goto unsupported;
++
++      /* Gather all possible format feature flags for the formats listed in
++       * the format list or all the compatible formats.
++       */
++      VkFormatFeatureFlags2 all_formats_feature_flags = format_feature_flags |
++         anv_formats_gather_format_features(devinfo, format, info->tiling,
++                                            isl_mod_info, format_list_info,
++                                            info->flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
++
++      if (!anv_format_supports_usage(all_formats_feature_flags, info->usage))
++         goto unsupported;
++   }
+ 
+    if (info->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+       /* We support modifiers only for "simple" (that is, non-array
+@@ -1110,7 +1305,7 @@ anv_get_image_format_properties(
+ 
+       if (isl_mod_info->aux_usage == ISL_AUX_USAGE_CCS_E &&
+           !anv_formats_ccs_e_compatible(devinfo, info->flags, info->format,
+-                                        info->tiling, image_usage,
++                                        info->tiling, info->usage,
+                                         format_list_info)) {
+          goto unsupported;
+       }
+@@ -1132,32 +1327,12 @@ anv_get_image_format_properties(
+        (format_feature_flags & (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
+                                 VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) &&
+        !(info->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) &&
+-       !(image_usage & VK_IMAGE_USAGE_STORAGE_BIT) &&
++       !(info->usage & VK_IMAGE_USAGE_STORAGE_BIT) &&
+        isl_format_supports_multisampling(devinfo, format->planes[0].isl_format)) {
+       sampleCounts = isl_device_get_sample_counts(&physical_device->isl_dev);
+    }
+ 
+-   if (view_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
+-      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
+-                                    VK_FORMAT_FEATURE_2_BLIT_SRC_BIT))) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) {
+-      if (!(format_feature_flags & (VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
+-                                    VK_FORMAT_FEATURE_2_BLIT_DST_BIT))) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (image_usage & VK_IMAGE_USAGE_STORAGE_BIT) {
++   if (info->usage & VK_IMAGE_USAGE_STORAGE_BIT) {
+       /* Non-power-of-two formats can never be used as storage images.  We
+        * only check plane 0 because there are no YCbCr formats with
+        * non-power-of-two planes.
+@@ -1168,24 +1343,6 @@ anv_get_image_format_properties(
+          goto unsupported;
+    }
+ 
+-   if (view_usage & VK_IMAGE_USAGE_STORAGE_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+-   if (view_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+-      if (!(format_feature_flags & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+-         goto unsupported;
+-      }
+-   }
+-
+    if (info->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
+       /* From the Vulkan 1.2.149 spec, VkImageCreateInfo:
+        *
+@@ -1240,16 +1397,6 @@ anv_get_image_format_properties(
+       }
+    }
+ 
+-   if (image_usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
+-      /* Nothing to check. */
+-   }
+-
+-   if (image_usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) {
+-      /* Ignore this flag because it was removed from the
+-       * provisional_I_20150910 header.
+-       */
+-   }
+-
+    /* From the bspec section entitled "Surface Layout and Tiling",
+     * Gfx9 has a 256 GB limitation and Gfx11+ has a 16 TB limitation.
+     */

--- a/pkgs/mesa-22.3.1-anv-patch/LICENSE
+++ b/pkgs/mesa-22.3.1-anv-patch/LICENSE
@@ -1,0 +1,83 @@
+The Mesa 3D Graphics Library
+
+Disclaimer
+
+   Mesa is a 3-D graphics library with an API which is very similar to
+   that of [1]OpenGL.* To the extent that Mesa utilizes the OpenGL command
+   syntax or state machine, it is being used with authorization from
+   [2]Silicon Graphics, Inc.(SGI). However, the author does not possess an
+   OpenGL license from SGI, and makes no claim that Mesa is in any way a
+   compatible replacement for OpenGL or associated with SGI. Those who
+   want a licensed implementation of OpenGL should contact a licensed
+   vendor.
+
+   Please do not refer to the library as MesaGL (for legal reasons). It's
+   just Mesa or The Mesa 3-D graphics library.
+
+   * OpenGL is a trademark of [3]Silicon Graphics Incorporated.
+
+License / Copyright Information
+
+   The Mesa distribution consists of several components. Different
+   copyrights and licenses apply to different components. For example, the
+   GLX client code uses the SGI Free Software License B, and some of the
+   Mesa device drivers are copyrighted by their authors. See below for a
+   list of Mesa's main components and the license for each.
+
+   The core Mesa library is licensed according to the terms of the MIT
+   license. This allows integration with the XFree86, Xorg and DRI
+   projects.
+
+   The default Mesa license is as follows:
+
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Attention, Contributors
+
+   When contributing to the Mesa project you must agree to the licensing
+   terms of the component to which you're contributing. The following
+   section lists the primary components of the Mesa distribution and their
+   respective licenses.
+
+Mesa Component Licenses
+
+Component         Location               License
+------------------------------------------------------------------
+Main Mesa code    src/mesa/              MIT
+
+Device drivers    src/mesa/drivers/*     MIT, generally
+
+Gallium code      src/gallium/           MIT
+
+Ext headers       include/GL/glext.h     Khronos
+                  include/GL/glxext.h
+
+GLX client code   src/glx/               SGI Free Software License B
+
+C11 thread        include/c11/threads*.h Boost (permissive) emulation
+
+   In general, consult the source files for license terms.
+
+References
+
+   1. https://www.opengl.org/
+   2. https://www.sgi.com/
+   3. https://www.sgi.com/

--- a/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
+++ b/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
@@ -3,11 +3,17 @@
 # Contributor: Jan de Groot <jgc@archlinux.org>
 # Contributor: Andreas Radke <andyrtr@archlinux.org>
 
-pkgbase=mesa
-pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-intel' 'vulkan-radeon' 'vulkan-swrast' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
-pkgdesc="An open-source implementation of the OpenGL specification"
+pkgbase=mesa-anv-patch
+pkgname=('vulkan-mesa-layers-anv-patch'
+				 'vulkan-intel-anv-patch'
+				 'vulkan-radeon-anv-patch'
+				 'vulkan-swrast-anv-patch'
+				 'libva-mesa-driver-anv-patch'
+				 'mesa-vdpau-anv-patch'
+				 'mesa-anv-patch')
+pkgdesc="An open-source implementation of the OpenGL specification - patched ANV for gamescope"
 pkgver=22.3.1
-pkgrel=2
+pkgrel=1
 arch=('x86_64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
@@ -50,11 +56,11 @@ build() {
     -D gallium-extra-hud=true \
     -D gallium-nine=true \
     -D gallium-omx=bellagio \
-    -D gallium-opencl=icd \
+    -D gallium-opencl=disabled \
     -D gallium-va=enabled \
     -D gallium-vdpau=enabled \
     -D gallium-xa=enabled \
-    -D gallium-rusticl=true \
+    -D gallium-rusticl=false \
     -D rust_std=2021 \
     -D gbm=enabled \
     -D gles1=disabled \
@@ -71,7 +77,7 @@ build() {
     -D valgrind=enabled
 
   # Print config
- meson configure --no-pager build
+  meson configure --no-pager build
 
   ninja -C build
   meson compile -C build
@@ -91,11 +97,12 @@ _install() {
   done
 }
 
-package_vulkan-mesa-layers() {
+package_vulkan-mesa-layers-anv-patch() {
   pkgdesc="Mesa's Vulkan layers"
   depends=('libdrm' 'libxcb' 'wayland' 'python')
-  conflicts=('vulkan-mesa-layer')
+  conflicts=('vulkan-mesa-layers' 'vulkan-mesa-layer')
   replaces=('vulkan-mesa-layer')
+  provides=('vulkan-mesa-layers')
 
   _install fakeinstall/usr/share/vulkan/explicit_layer.d
   _install fakeinstall/usr/share/vulkan/implicit_layer.d
@@ -105,24 +112,12 @@ package_vulkan-mesa-layers() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_opencl-mesa() {
-  pkgdesc="OpenCL support with clover and rusticl for mesa drivers"
-  depends=('libdrm' 'libclc' 'clang' 'expat')
-  optdepends=('opencl-headers: headers necessary for OpenCL development')
-  provides=('opencl-driver')
-
-  _install fakeinstall/etc/OpenCL
-  _install fakeinstall/usr/lib/lib*OpenCL*
-  _install fakeinstall/usr/lib/gallium-pipe
-
-  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
-}
-
-package_vulkan-intel() {
+package_vulkan-intel-anv-patch() {
   pkgdesc="Intel's Vulkan mesa driver"
   depends=('wayland' 'libx11' 'libxshmfence' 'libdrm' 'zstd' 'systemd-libs')
   optdepends=('vulkan-mesa-layers: additional vulkan layers')
   provides=('vulkan-driver')
+  conflicts=('vulkan-intel')
 
   _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
   _install fakeinstall/usr/lib/libvulkan_intel*.so
@@ -130,11 +125,12 @@ package_vulkan-intel() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_vulkan-radeon() {
+package_vulkan-radeon-anv-patch() {
   pkgdesc="Radeon's Vulkan mesa driver"
   depends=('wayland' 'libx11' 'libxshmfence' 'libelf' 'libdrm' 'llvm-libs' 'systemd-libs')
   optdepends=('vulkan-mesa-layers: additional vulkan layers')
   provides=('vulkan-driver')
+  conflicts=('vulkan-radeon')
 
   _install fakeinstall/usr/share/drirc.d/00-radv-defaults.conf
   _install fakeinstall/usr/share/vulkan/icd.d/radeon_icd*.json
@@ -143,13 +139,13 @@ package_vulkan-radeon() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_vulkan-swrast() {
+package_vulkan-swrast-anv-patch() {
   pkgdesc="Vulkan software rasteriser driver"
   depends=('wayland' 'libx11' 'libxshmfence' 'libdrm' 'zstd' 'llvm-libs' 'systemd-libs' 'libunwind')
   optdepends=('vulkan-mesa-layers: additional vulkan layers')
-  conflicts=('vulkan-mesa')
+  conflicts=('vulkan-swrast' 'vulkan-mesa')
   replaces=('vulkan-mesa')
-  provides=('vulkan-driver')
+  provides=('vulkan-swrast' 'vulkan-driver')
 
   _install fakeinstall/usr/share/vulkan/icd.d/lvp_icd*.json
   _install fakeinstall/usr/lib/libvulkan_lvp.so
@@ -157,27 +153,31 @@ package_vulkan-swrast() {
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_libva-mesa-driver() {
+package_libva-mesa-driver-anv-patch() {
   pkgdesc="VA-API implementation for gallium"
   depends=('libdrm' 'libx11' 'llvm-libs' 'expat' 'libelf' 'libxshmfence')
   depends+=('libexpat.so')
+	provides=('libva-mesa-driver')
+	conflicts=('libva-mesa-driver')
 
   _install fakeinstall/usr/lib/dri/*_drv_video.so
 
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_mesa-vdpau() {
+package_mesa-vdpau-anv-patch() {
   pkgdesc="Mesa VDPAU drivers"
   depends=('libdrm' 'libx11' 'llvm-libs' 'expat' 'libelf' 'libxshmfence')
   depends+=('libexpat.so')
+	provides=('mesa-vdpau')
+	conflicts=('mesa-vdpau')
 
   _install fakeinstall/usr/lib/vdpau
 
   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
 }
 
-package_mesa() {
+package_mesa-anv-patch() {
   depends=('libdrm' 'wayland' 'libxxf86vm' 'libxdamage' 'libxshmfence' 'libelf'
            'libomxil-bellagio' 'libunwind' 'llvm-libs' 'lm_sensors' 'libglvnd'
            'zstd' 'vulkan-icd-loader')
@@ -185,8 +185,8 @@ package_mesa() {
   optdepends=('opengl-man-pages: for the OpenGL API man pages'
               'mesa-vdpau: for accelerated video playback'
               'libva-mesa-driver: for accelerated video playback')
-  provides=('mesa-libgl' 'opengl-driver')
-  conflicts=('mesa-libgl')
+  provides=('mesa' 'mesa-libgl' 'opengl-driver')
+  conflicts=('mesa' 'mesa-libgl')
   replaces=('mesa-libgl')
 
   _install fakeinstall/usr/share/drirc.d/00-mesa-defaults.conf

--- a/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
+++ b/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
@@ -1,0 +1,217 @@
+# Maintainer: Laurent Carlier <lordheavym@gmail.com>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Andreas Radke <andyrtr@archlinux.org>
+
+pkgbase=mesa
+pkgname=('vulkan-mesa-layers' 'opencl-mesa' 'vulkan-intel' 'vulkan-radeon' 'vulkan-swrast' 'libva-mesa-driver' 'mesa-vdpau' 'mesa')
+pkgdesc="An open-source implementation of the OpenGL specification"
+pkgver=22.3.1
+pkgrel=2
+arch=('x86_64')
+makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
+             'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
+             'libomxil-bellagio' 'libclc' 'clang' 'libglvnd' 'libunwind' 'lm_sensors' 'libxrandr'
+             'systemd' 'valgrind' 'glslang' 'vulkan-icd-loader' 'directx-headers' 'cmake' 'meson')
+makedepends+=('rust' 'rust-bindgen' 'spirv-tools' 'spirv-llvm-translator') # rusticl dependencies
+url="https://www.mesa3d.org/"
+license=('custom')
+options=('debug' '!lto')
+source=(https://mesa.freedesktop.org/archive/mesa-${pkgver}.tar.xz
+        0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+        0001-anv-gamescope.patch
+        LICENSE)
+sha512sums=('SKIP' 'SKIP' 'SKIP' 'SKIP')
+
+prepare() {
+  cd mesa-$pkgver
+
+  # https://gitlab.freedesktop.org/mesa/mesa/-/issues/7111
+  # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/17247
+  # https://github.com/HansKristian-Work/vkd3d-proton/issues/1200
+  patch -Np1 -i ../0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+}
+
+build() {
+  # Build only minimal debug info to reduce size
+  CFLAGS+=' -g1'
+  CXXFLAGS+=' -g1'
+
+  arch-meson mesa-$pkgver build \
+    -D b_ndebug=true \
+    -D b_lto=false \
+    -D platforms=x11,wayland \
+    -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink,d3d12 \
+    -D vulkan-drivers=amd,intel,intel_hasvk,swrast \
+    -D vulkan-layers=device-select,intel-nullhw,overlay \
+    -D dri3=enabled \
+    -D egl=enabled \
+    -D gallium-extra-hud=true \
+    -D gallium-nine=true \
+    -D gallium-omx=bellagio \
+    -D gallium-opencl=icd \
+    -D gallium-va=enabled \
+    -D gallium-vdpau=enabled \
+    -D gallium-xa=enabled \
+    -D gallium-rusticl=true \
+    -D rust_std=2021 \
+    -D gbm=enabled \
+    -D gles1=disabled \
+    -D gles2=enabled \
+    -D glvnd=true \
+    -D glx=dri \
+    -D libunwind=enabled \
+    -D llvm=enabled \
+    -D lmsensors=enabled \
+    -D osmesa=true \
+    -D shared-glapi=enabled \
+    -D microsoft-clc=disabled \
+    -D video-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
+    -D valgrind=enabled
+
+  # Print config
+ meson configure --no-pager build
+
+  ninja -C build
+  meson compile -C build
+
+  # fake installation to be seperated into packages
+  # outside of fakeroot but mesa doesn't need to chown/mod
+  DESTDIR="${srcdir}/fakeinstall" meson install -C build
+}
+
+_install() {
+  local src f dir
+  for src; do
+    f="${src#fakeinstall/}"
+    dir="${pkgdir}/${f%/*}"
+    install -m755 -d "${dir}"
+    mv -v "${src}" "${dir}/"
+  done
+}
+
+package_vulkan-mesa-layers() {
+  pkgdesc="Mesa's Vulkan layers"
+  depends=('libdrm' 'libxcb' 'wayland' 'python')
+  conflicts=('vulkan-mesa-layer')
+  replaces=('vulkan-mesa-layer')
+
+  _install fakeinstall/usr/share/vulkan/explicit_layer.d
+  _install fakeinstall/usr/share/vulkan/implicit_layer.d
+  _install fakeinstall/usr/lib/libVkLayer_*.so
+  _install fakeinstall/usr/bin/mesa-overlay-control.py
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_opencl-mesa() {
+  pkgdesc="OpenCL support with clover and rusticl for mesa drivers"
+  depends=('libdrm' 'libclc' 'clang' 'expat')
+  optdepends=('opencl-headers: headers necessary for OpenCL development')
+  provides=('opencl-driver')
+
+  _install fakeinstall/etc/OpenCL
+  _install fakeinstall/usr/lib/lib*OpenCL*
+  _install fakeinstall/usr/lib/gallium-pipe
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_vulkan-intel() {
+  pkgdesc="Intel's Vulkan mesa driver"
+  depends=('wayland' 'libx11' 'libxshmfence' 'libdrm' 'zstd' 'systemd-libs')
+  optdepends=('vulkan-mesa-layers: additional vulkan layers')
+  provides=('vulkan-driver')
+
+  _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
+  _install fakeinstall/usr/lib/libvulkan_intel*.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_vulkan-radeon() {
+  pkgdesc="Radeon's Vulkan mesa driver"
+  depends=('wayland' 'libx11' 'libxshmfence' 'libelf' 'libdrm' 'llvm-libs' 'systemd-libs')
+  optdepends=('vulkan-mesa-layers: additional vulkan layers')
+  provides=('vulkan-driver')
+
+  _install fakeinstall/usr/share/drirc.d/00-radv-defaults.conf
+  _install fakeinstall/usr/share/vulkan/icd.d/radeon_icd*.json
+  _install fakeinstall/usr/lib/libvulkan_radeon.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_vulkan-swrast() {
+  pkgdesc="Vulkan software rasteriser driver"
+  depends=('wayland' 'libx11' 'libxshmfence' 'libdrm' 'zstd' 'llvm-libs' 'systemd-libs' 'libunwind')
+  optdepends=('vulkan-mesa-layers: additional vulkan layers')
+  conflicts=('vulkan-mesa')
+  replaces=('vulkan-mesa')
+  provides=('vulkan-driver')
+
+  _install fakeinstall/usr/share/vulkan/icd.d/lvp_icd*.json
+  _install fakeinstall/usr/lib/libvulkan_lvp.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_libva-mesa-driver() {
+  pkgdesc="VA-API implementation for gallium"
+  depends=('libdrm' 'libx11' 'llvm-libs' 'expat' 'libelf' 'libxshmfence')
+  depends+=('libexpat.so')
+
+  _install fakeinstall/usr/lib/dri/*_drv_video.so
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_mesa-vdpau() {
+  pkgdesc="Mesa VDPAU drivers"
+  depends=('libdrm' 'libx11' 'llvm-libs' 'expat' 'libelf' 'libxshmfence')
+  depends+=('libexpat.so')
+
+  _install fakeinstall/usr/lib/vdpau
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}
+
+package_mesa() {
+  depends=('libdrm' 'wayland' 'libxxf86vm' 'libxdamage' 'libxshmfence' 'libelf'
+           'libomxil-bellagio' 'libunwind' 'llvm-libs' 'lm_sensors' 'libglvnd'
+           'zstd' 'vulkan-icd-loader')
+  depends+=('libsensors.so' 'libexpat.so' 'libvulkan.so')
+  optdepends=('opengl-man-pages: for the OpenGL API man pages'
+              'mesa-vdpau: for accelerated video playback'
+              'libva-mesa-driver: for accelerated video playback')
+  provides=('mesa-libgl' 'opengl-driver')
+  conflicts=('mesa-libgl')
+  replaces=('mesa-libgl')
+
+  _install fakeinstall/usr/share/drirc.d/00-mesa-defaults.conf
+  _install fakeinstall/usr/share/glvnd/egl_vendor.d/50_mesa.json
+
+  # ati-dri, nouveau-dri, intel-dri, svga-dri, swrast, swr
+  _install fakeinstall/usr/lib/dri/*_dri.so
+
+  _install fakeinstall/usr/lib/bellagio
+  _install fakeinstall/usr/lib/d3d
+  _install fakeinstall/usr/lib/lib{gbm,glapi}.so*
+  _install fakeinstall/usr/lib/libOSMesa.so*
+  _install fakeinstall/usr/lib/libxatracker.so*
+
+  _install fakeinstall/usr/include
+  _install fakeinstall/usr/lib/pkgconfig
+
+  # libglvnd support
+  _install fakeinstall/usr/lib/libGLX_mesa.so*
+  _install fakeinstall/usr/lib/libEGL_mesa.so*
+
+  # indirect rendering
+  ln -s /usr/lib/libGLX_mesa.so.0 "${pkgdir}/usr/lib/libGLX_indirect.so.0"
+
+  # make sure there are no files left to install
+  find fakeinstall -depth -print0 | xargs -0 rmdir
+
+  install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE
+}

--- a/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
+++ b/pkgs/mesa-22.3.1-anv-patch/PKGBUILD
@@ -30,6 +30,7 @@ prepare() {
   # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/17247
   # https://github.com/HansKristian-Work/vkd3d-proton/issues/1200
   patch -Np1 -i ../0001-anv-force-MEDIA_INTERFACE_DESCRIPTOR_LOAD-reemit-aft.patch
+  patch -Np1 -i ../0001-anv-gamescope.patch
 }
 
 build() {


### PR DESCRIPTION
We're using the Arch Linux's PKGBUILD including the additional ANV patch to fix the issues where gamescope would fail on Intel devices.

The patches only effect Intel specific files called `ISL_FORMAT` and `ANV_FORMATS`