### PR TITLE
Add ryzenadj-controller

### DIFF
--- a/manifest
+++ b/manifest
@@ -152,6 +152,7 @@ export AUR_PACKAGES="\
 	rtl88x2bu-dkms-git \
 	rtw89-dkms-git \
 	ryzenadj-git \
+	ryzenadj-controller-git \
 	rz608-fix-git \
 	steam-removable-media-git \
 	steamos-compositor-plus \
@@ -173,6 +174,7 @@ export SERVICES="\
 	handycon \
 	haveged \
 	lightdm \
+	ryzenadj-controller
 	sshd \
 	systemd-timesyncd \
 "
@@ -180,6 +182,7 @@ export SERVICES="\
 export USER_SERVICES="\
 	chimera.service \
 	gamemoded.service \
+	ryzen-tctl \
 	steam-patch.service \
 	sxhkd.service \
 "


### PR DESCRIPTION
Adds ryzenadj-controller-git and enables user service that depends on it from device-quirks.