### PR TITLE
Remove r8168 driver

### DIFF
--- a/manifest
+++ b/manifest
@@ -145,7 +145,6 @@ export AUR_PACKAGES="\
 	python-inotify-simple \
 	python-vdf \
 	r8152-dkms \
-	r8168-dkms \
 	retroarch-autoconfig-udev-git \
 	rtl8812au-dkms-git \
 	rtl8814au-dkms-git \

--- a/pkgs/r8168-dkms/PKGBUILD
+++ b/pkgs/r8168-dkms/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Patrick Northon <northon_patrick3@yahoo.ca>
+# Contributor: René Wagner <rwa at clttr dot info>
+# Contributor: Juan Simón <play4pro at protonmail dot com>
+# Contributor: alium
+# Contributor: angelsl
+# Contributor: hayao <hayao@fascode.net>
+
+_pkgbase=r8168
+pkgname=${_pkgbase}-dkms
+pkgver=8.051.02
+pkgrel=2
+pkgdesc="A kernel module for Realtek 8168 network cards (DKMS version)"
+url="https://github.com/mtorromeo/r8168"
+license=("GPL")
+arch=('i686' 'x86_64')
+depends=('glibc' 'dkms')
+makedepends=('git')
+conflicts=("${_pkgbase}")
+provides=("${_pkgbase}")
+source=("r8168-dkms::git+https://github.com/mtorromeo/r8168.git"
+        "${pkgname}-6.1.patch::https://github.com/mtorromeo/r8168/pull/47.patch"
+        "dkms.conf")
+sha256sums=('SKIP'
+            'b7ef09e7496715b7576b7a3bff5a96e0e07c0bb02cd5bb5805415be20b883f60'
+            'd37b8acbd4fe06f81538581712a04751a96fc37bad3a4bd3ae8329f8744c49b3')
+install=r8168-dkms.install
+
+prepare() {
+	cd "${pkgname}"
+	patch -p1 -i "$srcdir/${pkgname}-6.1.patch"
+}
+
+package() {
+	install -Dm644 dkms.conf "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/dkms.conf"
+
+	sed -e "s/@PKGNAME@/${_pkgbase}/g" \
+	    -e "s/@PKGVER@/${pkgver}/g" \
+	    -i "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/dkms.conf"
+
+	cd "${pkgname}"
+	cp -dr --no-preserve='ownership' src "${pkgdir}/usr/src/${_pkgbase}-${pkgver}/src"
+}

--- a/pkgs/r8168-dkms/dkms.conf
+++ b/pkgs/r8168-dkms/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="@PKGNAME@"
+PACKAGE_VERSION="@PKGVER@"
+MAKE[0]="make -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build/src EXTRA_CFLAGS='-DCONFIG_R8168_NAPI=y -DCONFIG_R8168_VLAN=y -DCONFIG_ASPM=y -DENABLE_S5WOL=y -DENABLE_EEE=y' modules"
+CLEAN="rm src/@PKGNAME@.ko src/*.o || true"
+BUILT_MODULE_NAME[0]="@PKGNAME@"
+BUILT_MODULE_LOCATION[0]="src/"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/ethernet/realtek"
+AUTOINSTALL="yes"

--- a/pkgs/r8168-dkms/r8168-dkms.install
+++ b/pkgs/r8168-dkms/r8168-dkms.install
@@ -1,0 +1,15 @@
+post_install() {
+  dkms add r8168/${1%-*}
+}
+
+pre_upgrade() {
+  pre_remove "$2"
+}
+
+post_upgrade() {
+  post_install "$1"
+}
+
+pre_remove() {
+  [ -n "${1%-*}" ] && dkms remove r8168/${1%-*} --all &>/dev/null || true
+}


### PR DESCRIPTION
Causes regressions with r8169 driver. The package blacklists r8169 kernel module and can't be reenabled automatically. Maybe if there are enough users with this chip, we should redo the packaging without the blacklisting part.