### PR TITLE
Jupiter deps

### DIFF
--- a/manifest
+++ b/manifest
@@ -50,15 +50,19 @@ export PACKAGES="\
 	intel-ucode \
 	intel-undervolt \
 	lib32-curl \
+	lib32-fontconfig \
 	lib32-freetype2 \
 	lib32-gamemode \
 	lib32-libgpg-error \
 	lib32-libnm \
+	lib32-libxinerama \
+	lib32-libva \
 	lib32-libva-intel-driver \
 	lib32-libva-vdpau-driver \
 	lib32-nvidia-utils \
 	lib32-openal \
 	lib32-pipewire \
+	lib32-systemd \
 	lib32-vulkan-icd-loader \
 	libcurl-gnutls \
 	libidn11 \

--- a/manifest
+++ b/manifest
@@ -56,6 +56,7 @@ export PACKAGES="\
 	lib32-libgpg-error \
 	lib32-libnm \
 	lib32-libxinerama \
+	lib32-libxcrypt-compat \
 	lib32-libva \
 	lib32-libva-intel-driver \
 	lib32-libva-vdpau-driver \
@@ -82,6 +83,7 @@ export PACKAGES="\
 	libretro-snes9x \
 	libva-intel-driver \
 	libva-vdpau-driver \
+	libxcrypt-compat \
 	lightdm \
 	linux-firmware \
 	liquidctl \


### PR DESCRIPTION
From PKGBUILD:
```
# libxcrypt-compat, lib32-libxcrypt-compat: https://bugs.archlinux.org/task/75443
# lib32-pipewire: https://bugs.archlinux.org/task/75155
# lib32-fontconfig: https://bugs.archlinux.org/task/74827
# lib32-systemd, lib32-libxinerama: https://bugs.archlinux.org/task/75156
# lib32-libnm, lib32-libva:  https://bugs.archlinux.org/task/75157
```

Some are already there by dependencies in other places. But this makes them explicit.