### PR TITLE
Add Citra, Mesen-S, and ProSystem libretro core packages

### DIFF
--- a/manifest
+++ b/manifest
@@ -70,6 +70,7 @@ export PACKAGES="\
 	libidn11 \
 	libretro-beetle-pce-fast \
 	libretro-beetle-psx-hw \
+	libretro-citra \
 	libretro-desmume \
 	libretro-dolphin \
 	libretro-flycast \

--- a/manifest
+++ b/manifest
@@ -76,12 +76,14 @@ export PACKAGES="\
 	libretro-genesis-plus-gx \
 	libretro-kronos \
 	libretro-mame \
+	libretro-mesen-s\
 	libretro-mgba \
 	libretro-mupen64plus-next \
 	libretro-nestopia \
 	libretro-picodrive \
 	libretro-play \
 	libretro-ppsspp \
+	libretro-prosystem \
 	libretro-snes9x \
 	libva-intel-driver \
 	libva-vdpau-driver \


### PR DESCRIPTION
dependencies for adding Atari 7800 and SuperGameBoy support (draft pull request 260 https://github.com/ChimeraOS/chimera/pull/260 )