### PR TITLE
Fix position issues with mangoapp

### DIFF
--- a/pkgs/50-mangohud/PKGBUILD
+++ b/pkgs/50-mangohud/PKGBUILD
@@ -14,7 +14,8 @@ source=("mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#commit=
         "imgui-1.81-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/imgui/1.81/1/get_zip"
         "spdlog-1.8.5.tar.gz::https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz"
         "spdlog-1.8.5-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.8.5/1/get_zip"
-        "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip")
+        "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip"
+        "resolution.patch")
 
 sha256sums=('SKIP'
             'SKIP'
@@ -22,7 +23,8 @@ sha256sums=('SKIP'
             '6d00b442690b6a5c5d8f898311daafbce16d370cf64f53294c3b8c5c661e435f'
             '944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8'
             '3c38f275d5792b1286391102594329e98b17737924b344f98312ab09929b74be'
-            'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e')
+            'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e'
+            'SKIP')
 
 _build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Duse_system_vulkan=enabled -Dmangoapp_layer=true -Dprepend_libdir_vk=false"
 
@@ -45,6 +47,8 @@ prepare() {
   ln -sv "$srcdir/single_include" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/LICENSE.MIT" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/meson.build" subprojects/nlohmann_json-3.10.5/
+  
+    patch -Np1 -i ../resolution.patch
 }
 
 build() {

--- a/pkgs/50-mangohud/resolution.patch
+++ b/pkgs/50-mangohud/resolution.patch
@@ -1,8 +1,8 @@
 diff --git a/src/app/main.cpp b/src/app/main.cpp
-index ead0384..2f9a663 100644
+index ead0384..07051e9 100644
 --- a/src/app/main.cpp
 +++ b/src/app/main.cpp
-@@ -187,9 +187,20 @@ static void msg_read_thread(){
+@@ -187,11 +187,23 @@ static void msg_read_thread(){
  }
  
  static const char *GamescopeOverlayProperty = "GAMESCOPE_EXTERNAL_OVERLAY";
@@ -23,13 +23,19 @@ index ead0384..2f9a663 100644
 +    GLFWwindow *window = glfwCreateWindow(screen_width, screen_height, "mangoapp overlay window", NULL, NULL);
      Display *x11_display = glfwGetX11Display();
      Window x11_window = glfwGetX11Window(window);
++
      if (x11_window && x11_display)
-@@ -227,7 +238,7 @@ static bool render(GLFWwindow* window) {
+     {
+         // Set atom for gamescope to render as an overlay.
+@@ -227,7 +239,10 @@ static bool render(GLFWwindow* window) {
      position_layer(sw_stats, params, window_size);
      render_imgui(sw_stats, params, window_size, true);
      overlay_end_frame();
 -    glfwSetWindowSize(window, 1280, 800);
-+    glfwSetWindowSize(window, screen_width, screen_height);
++        
++    const GLFWvidmode * mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
++ 
++    glfwSetWindowMonitor(window, glfwGetPrimaryMonitor(), 0, 0, mode->width, mode->height, mode->refreshRate);
      ImGui::EndFrame();
      return last_window_size.x != window_size.x || last_window_size.y != window_size.y;
  }

--- a/pkgs/50-mangohud/resolution.patch
+++ b/pkgs/50-mangohud/resolution.patch
@@ -1,0 +1,35 @@
+diff --git a/src/app/main.cpp b/src/app/main.cpp
+index ead0384..2f9a663 100644
+--- a/src/app/main.cpp
++++ b/src/app/main.cpp
+@@ -187,9 +187,20 @@ static void msg_read_thread(){
+ }
+ 
+ static const char *GamescopeOverlayProperty = "GAMESCOPE_EXTERNAL_OVERLAY";
++int screen_width;
++int screen_height;
++
++void get_resolution() {
++    const GLFWvidmode * mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
++
++    screen_width = mode->width;
++    screen_height = mode->height;
++}
++
+ 
+ static GLFWwindow* init(const char* glsl_version){
+-    GLFWwindow *window = glfwCreateWindow(1280, 800, "mangoapp overlay window", NULL, NULL);
++    get_resolution();
++    GLFWwindow *window = glfwCreateWindow(screen_width, screen_height, "mangoapp overlay window", NULL, NULL);
+     Display *x11_display = glfwGetX11Display();
+     Window x11_window = glfwGetX11Window(window);
+     if (x11_window && x11_display)
+@@ -227,7 +238,7 @@ static bool render(GLFWwindow* window) {
+     position_layer(sw_stats, params, window_size);
+     render_imgui(sw_stats, params, window_size, true);
+     overlay_end_frame();
+-    glfwSetWindowSize(window, 1280, 800);
++    glfwSetWindowSize(window, screen_width, screen_height);
+     ImGui::EndFrame();
+     return last_window_size.x != window_size.x || last_window_size.y != window_size.y;
+ }


### PR DESCRIPTION
Confirmed to fix issues on devices that don't rely on specifying a `-w` `-h` nested value to work such as the intel One Xplayer 1S.

- Fixes the position of the performance overlay on the Aokzoe and Aya Neo Air