### PR TITLE
Mangohud revert after issues on Intel

### DIFF
--- a/pkgs/50-mangohud/PKGBUILD
+++ b/pkgs/50-mangohud/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Simon Hallsten <flightlessmangoyt@gmail.com>
 pkgname=('mangohud' 'lib32-mangohud')
-pkgver=0.6.8.r145.g020e848
-pkgrel=1
+pkgver=0.6.8.r145.g3190778
+pkgrel=2
 pkgdesc="Vulkan and OpenGL overlay to display performance information"
 arch=('x86_64')
 makedepends=('dbus' 'gcc' 'meson' 'python-mako' 'libx11' 'lib32-libx11' 'git' 'pkgconf' 'vulkan-headers' 'appstream'
@@ -11,7 +11,7 @@ depends=('glslang' 'libglvnd' 'lib32-libglvnd' 'glew' 'glfw-x11')
 replaces=('vulkan-mesa-layer-mango')
 license=('MIT')
 source=(
-        "mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#commit=020e8485e20c250c34240f9cca244394e9a3204c"
+        "mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#commit=319077808668c589523853313d028cf81837ce72"
         "mangohud-minhook"::"git+https://github.com/flightlessmango/minhook.git"
         "imgui-v1.81.tar.gz::https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
         "imgui-1.81-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/imgui/1.81/1/get_zip"
@@ -91,5 +91,4 @@ package_lib32-mangohud() {
   DESTDIR="${pkgdir}" ninja -C build32 install
   rm -rf "$pkgdir/usr/bin"
   rm -rf "$pkgdir/usr/share"
-  install -m644 -Dt "$pkgdir/usr/share/vulkan/implicit_layer.d" "$srcdir/build32/src/MangoHud.x86.json"
 }


### PR DESCRIPTION
Apparantly mangohud broke stuff on intel. Reverting to the old mangohud we had before, but keeping the subproject vulkan-headers.

See also:
https://github.com/flightlessmango/MangoHud/issues/850
https://github.com/flightlessmango/MangoHud/pull/877
https://gitlab.freedesktop.org/drm/intel/-/issues/5018