### PR TITLE
Manually use 0.3.67 pipewire for now

### DIFF
--- a/pkgs/50-pipewire/PKGBUILD
+++ b/pkgs/50-pipewire/PKGBUILD
@@ -1,0 +1,421 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+
+pkgbase=pipewire
+pkgname=(
+  pipewire
+  libpipewire
+  alsa-card-profiles
+  pipewire-docs
+  pipewire-audio
+  pipewire-alsa
+  pipewire-jack
+  pipewire-pulse
+  pipewire-roc
+  gst-plugin-pipewire
+  pipewire-zeroconf
+  pipewire-v4l2
+  pipewire-x11-bell
+)
+_commit=26623ff8cb3c9ba774537379a1835c5efb0d5159  # tags/0.3.67
+pkgver=0.3.67
+pkgrel=1
+epoch=1
+pkgdesc="Low-latency audio/video router and processor"
+url="https://pipewire.org"
+arch=(x86_64)
+license=(MIT)
+makedepends=(
+  alsa-lib
+  avahi
+  bluez-libs
+  dbus
+  doxygen
+  git
+  glib2
+  graphviz
+  gst-plugins-base
+  libcamera
+  libcanberra
+  libfdk-aac
+  libfreeaptx
+  liblc3
+  libldac
+  libmysofa
+  libpulse
+  libsndfile
+  libusb
+  libx11
+  libxfixes
+  lilv
+  meson
+  ncurses
+  opus
+  python-docutils
+  readline
+  roc-toolkit
+  rtkit
+  sbc
+  sdl2
+  systemd
+  tinycompress
+  valgrind
+  webrtc-audio-processing
+)
+checkdepends=(desktop-file-utils)
+source=(git+https://gitlab.freedesktop.org/pipewire/pipewire.git#commit=$_commit)
+sha256sums=('SKIP')
+
+pkgver() {
+  cd pipewire
+  git describe --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {
+  cd pipewire
+
+  # remove export of LD_LIBRARY_PATH for pw-jack as it would add /usr/lib
+  sed -i '/LD_LIBRARY_PATH/d' pipewire-jack/src/pw-jack.in
+}
+
+build() {
+  local meson_options=(
+    -D bluez5-codec-lc3=enabled
+    -D bluez5-codec-lc3plus=disabled
+    -D compress-offload=enabled
+    -D docs=enabled
+    -D jack-devel=true
+    -D jack=disabled
+    -D libjack-path=/usr/lib
+    -D rlimits-install=false
+    -D session-managers=[]
+    -D udevrulesdir=/usr/lib/udev/rules.d
+  )
+
+  arch-meson pipewire build "${meson_options[@]}"
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+_pick() {
+  local p="$1" f d; shift
+  for f; do
+    d="$srcdir/$p/${f#$pkgdir/}"
+    mkdir -p "$(dirname "$d")"
+    mv "$f" "$d"
+    rmdir -p --ignore-fail-on-non-empty "$(dirname "$f")"
+  done
+}
+
+_ver=${pkgver:0:3}
+
+package_pipewire() {
+  license+=(LGPL)  # libspa-alsa
+  depends=(
+    "libpipewire=$epoch:$pkgver-$pkgrel"
+    libcamera-base.so
+    libcamera.so
+    libdbus-1.so
+    libglib-2.0.so
+    libncursesw.so
+    libpipewire-$_ver.so
+    libreadline.so
+    libsystemd.so
+    libudev.so
+  )
+  optdepends=(
+    'gst-plugin-pipewire: GStreamer plugin'
+    'pipewire-alsa: ALSA configuration'
+    'pipewire-audio: Audio support'
+    'pipewire-docs: Documentation'
+    'pipewire-jack: JACK support'
+    'pipewire-pulse: PulseAudio replacement'
+    'pipewire-roc: ROC streaming'
+    'pipewire-session-manager: Session manager'
+    'pipewire-v4l2: V4L2 interceptor'
+    'pipewire-x11-bell: X11 bell'
+    'pipewire-zeroconf: Zeroconf support'
+    'realtime-privileges: realtime privileges with rt module'
+    'rtkit: realtime privileges with rtkit module'
+  )
+  install=pipewire.install
+
+  meson install -C build --destdir "$pkgdir"
+
+  (
+    cd "$pkgdir"
+
+    # Replace copies with symlinks
+    for _f in pipewire-{aes67,avb,pulse}; do
+      cmp usr/bin/pipewire usr/bin/$_f
+      ln -sf pipewire usr/bin/$_f
+    done
+
+    _pick lib usr/include/{pipewire-$_ver,spa-0.2}
+    _pick lib usr/lib/libpipewire-$_ver.so*
+    _pick lib usr/lib/pkgconfig/lib{pipewire-$_ver,spa-0.2}.pc
+
+    _pick acp usr/lib/udev
+    _pick acp usr/share/alsa-card-profile
+
+    _pick docs usr/share/doc
+
+    _pick audio usr/bin/pipewire-{aes67,avb}
+    _pick audio usr/bin/pw-{cat,{,enc}play,record,midi{play,record},dsdplay}
+    _pick audio usr/bin/pw-{loopback,mididump}
+    _pick audio usr/bin/spa-{acp-tool,resample}
+    _pick audio usr/lib/alsa-lib
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-avb.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-echo-cancel.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-fallback-sink.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-filter-chain.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-loopback.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-pipe-tunnel.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-protocol-simple.so
+    _pick audio usr/lib/pipewire-$_ver/libpipewire-module-rtp-*.so
+    _pick audio usr/lib/spa-0.2/{aec,alsa,audio*,avb,bluez5}
+    _pick audio usr/lib/systemd/user/filter-chain.service
+    _pick audio usr/share/alsa
+    _pick audio usr/share/man/man1/pw-{cat,mididump}.1
+    _pick audio usr/share/pipewire/filter-chain*
+    _pick audio usr/share/pipewire/pipewire-{aes67,avb}.conf
+    _pick audio usr/share/spa-0.2/bluez5
+
+    _pick jack usr/bin/pw-jack
+    _pick jack usr/include/jack
+    _pick jack usr/lib/libjack*
+    _pick jack usr/lib/pkgconfig/jack.pc
+    _pick jack usr/share/man/man1/pw-jack.1
+    _pick jack usr/share/pipewire/jack.conf
+
+    _pick pulse usr/bin/pipewire-pulse
+    _pick pulse usr/lib/pipewire-$_ver/libpipewire-module-protocol-pulse.so
+    _pick pulse usr/lib/pipewire-$_ver/libpipewire-module-pulse-tunnel.so
+    _pick pulse usr/lib/systemd/user/pipewire-pulse.*
+    _pick pulse usr/share/man/man1/pipewire-pulse.1
+    _pick pulse usr/share/pipewire/pipewire-pulse.conf
+
+    _pick roc usr/lib/pipewire-$_ver/libpipewire-module-roc*.so
+
+    _pick gst usr/lib/gstreamer-1.0
+
+    _pick zeroconf usr/lib/pipewire-$_ver/libpipewire-module-{raop,zeroconf}-*.so
+
+    _pick v4l2 usr/bin/pw-v4l2 usr/lib/pipewire-$_ver/v4l2
+
+    _pick x11-bell usr/lib/pipewire-$_ver/libpipewire-module-x11-bell.so
+
+    # directories for overrides
+    mkdir -p etc/pipewire/{client-rt,client,minimal,pipewire}.conf.d
+  )
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_libpipewire() {
+  pkgdesc+=" - client library"
+  depends=(
+    gcc-libs
+  )
+  provides=(libpipewire-$_ver.so)
+
+  mv lib/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_alsa-card-profiles() {
+  pkgdesc+=" - ALSA card profiles"
+  license=(LGPL)
+
+  mv acp/* "$pkgdir"
+}
+
+package_pipewire-docs() {
+  pkgdesc+=" - documentation"
+
+  mv docs/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-audio() {
+  pkgdesc+=" - Audio support"
+  depends=(
+    alsa-card-profiles
+    libasound.so
+    libbluetooth.so
+    libfdk-aac.so
+    libfreeaptx.so
+    liblc3.so
+    libldacBT_enc.so
+    liblilv-0.so
+    libmysofa.so
+    libopus.so
+    libpipewire-$_ver.so
+    libsbc.so
+    libsndfile.so
+    libtinycompress.so
+    libusb-1.0.so
+    libwebrtc_audio_processing.so
+    pipewire
+  )
+
+  mv audio/* "$pkgdir"
+
+  mkdir -p "$pkgdir/etc/alsa/conf.d"
+  ln -st "$pkgdir/etc/alsa/conf.d" \
+    /usr/share/alsa/alsa.conf.d/50-pipewire.conf
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-alsa() {
+  pkgdesc+=" - ALSA configuration"
+  depends=(
+    pipewire
+    pipewire-audio
+    pipewire-session-manager
+  )
+  conflicts=(pulseaudio-alsa)
+  provides=(pulseaudio-alsa)
+
+  mkdir -p "$pkgdir/etc/alsa/conf.d"
+  ln -st "$pkgdir/etc/alsa/conf.d" \
+    /usr/share/alsa/alsa.conf.d/99-pipewire-default.conf
+
+  install -Dm644 /dev/null \
+    "$pkgdir/usr/share/pipewire/media-session.d/with-alsa"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-jack() {
+  pkgdesc+=" - JACK support"
+  license+=(GPL2)  # libjackserver
+  depends=(
+    libpipewire-$_ver.so
+    pipewire
+    pipewire-audio
+    pipewire-session-manager
+    sh
+  )
+  optdepends=('jack-example-tools: for official JACK example-clients and tools')
+  conflicts=(jack jack2)
+  provides=(jack libjack.so libjackserver.so libjacknet.so)
+
+  mv jack/* "$pkgdir"
+
+  install -Dm644 /dev/null \
+    "$pkgdir/usr/share/pipewire/media-session.d/with-jack"
+
+  # directories for overrides
+  mkdir -p "$pkgdir/etc/pipewire/jack.conf.d"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-pulse() {
+  pkgdesc+=" - PulseAudio replacement"
+  depends=(
+    libavahi-{client,common}.so
+    libglib-2.0.so
+    libpipewire-$_ver.so
+    libpulse.so
+    pipewire
+    pipewire-audio
+    pipewire-session-manager
+  )
+  provides=(pulseaudio pulseaudio-bluetooth)
+  conflicts=(pulseaudio pulseaudio-bluetooth)
+  install=pipewire-pulse.install
+
+  mv pulse/* "$pkgdir"
+
+  # directory for overrides
+  mkdir -p "$pkgdir/etc/pipewire/pipewire-pulse.conf.d"
+
+  install -Dm644 /dev/null \
+    "$pkgdir/usr/share/pipewire/media-session.d/with-pulseaudio"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-roc() {
+  pkgdesc+=" - ROC streaming support"
+  depends=(
+    libpipewire-$_ver.so
+    libroc.so
+    pipewire
+    pipewire-audio
+    roc-toolkit
+  )
+
+  mv roc/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_gst-plugin-pipewire() {
+  pkgdesc="Multimedia graph framework - pipewire plugin"
+  depends=(
+    gst-plugins-base-libs
+    libpipewire-$_ver.so
+    pipewire
+    pipewire-session-manager
+  )
+
+  mv gst/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-zeroconf() {
+  pkgdesc+=" - Zeroconf support"
+  depends=(
+    libavahi-{client,common}.so
+    libpipewire-$_ver.so
+    openssl
+    pipewire
+  )
+
+  mv zeroconf/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-v4l2() {
+  pkgdesc+=" - V4L2 interceptor"
+  depends=(
+    libpipewire-$_ver.so
+    pipewire
+    pipewire-session-manager
+    sh
+  )
+
+  mv v4l2/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+package_pipewire-x11-bell() {
+  pkgdesc+=" - X11 bell"
+  depends=(
+    libcanberra.so
+    libpipewire-$_ver.so
+    libx11
+    libxfixes
+    pipewire
+    pipewire-audio
+  )
+
+  mv x11-bell/* "$pkgdir"
+
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 pipewire/COPYING
+}
+
+# vim:set sw=2 sts=-1 et:

--- a/pkgs/50-pipewire/pipewire-pulse.install
+++ b/pkgs/50-pipewire/pipewire-pulse.install
@@ -1,0 +1,14 @@
+post_install() {
+  # Enable socket by default
+  systemctl --global enable pipewire-pulse.socket
+}
+
+post_upgrade() {
+  if (( $(vercmp $2 0.3.16-1) < 0)); then
+    systemctl --global enable pipewire-pulse.socket
+  fi
+}
+
+pre_remove() {
+  systemctl --global disable pipewire-pulse.socket
+}

--- a/pkgs/50-pipewire/pipewire.install
+++ b/pkgs/50-pipewire/pipewire.install
@@ -1,0 +1,14 @@
+post_install() {
+  # Enable socket by default
+  systemctl --global enable pipewire.socket
+}
+
+post_upgrade() {
+  if (( $(vercmp $2 0.1.6-2) < 0)); then
+    systemctl --global enable pipewire.socket
+  fi
+}
+
+pre_remove() {
+  systemctl --global disable pipewire.socket
+}


### PR DESCRIPTION
0.3.68 breaks the `-steamos3` parameter and it's undetermined whether it's Valve or the upstream project's "bug" to fix. We may need to start reverting or patching pipewire in the feature depending on what happens.

Related tickets:
- https://github.com/ValveSoftware/steam-for-linux/issues/9337
- https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3145