### PR TITLE
Add downgrade utility

### DIFF
--- a/manifest
+++ b/manifest
@@ -146,6 +146,7 @@ export AUR_PACKAGES="\
 	boxtron \
 	chimera \
 	chimeraos-device-quirks-git \
+	downgrade \
 	frzr \
 	gamescope-plus \
 	gamescope-session-git \


### PR DESCRIPTION
This downgrade utility makes it easier to fetch packages from the archive for installation. 
- Makes it easier to confirm regressions with packages
- Makes it easier for users to resolve issues without needing us to try to rush out a fix or workaround