### PR TITLE
Add sshfs for remote mounting support

### DIFF
--- a/manifest
+++ b/manifest
@@ -121,6 +121,7 @@ export PACKAGES="\
 	rsync \
 	smbclient \
 	sof-firmware \
+	sshfs \
 	steam \
 	sudo \
 	ttf-liberation \


### PR DESCRIPTION
The immediate benefit to this is for remote frzr deployments but this has many other use cases as well I'd like to build on.