### PR TITLE
Upgrade mangohud to 0.6.9

### DIFF
--- a/pkgs/50-mangohud/PKGBUILD
+++ b/pkgs/50-mangohud/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Simon Hallsten <flightlessmangoyt@gmail.com>
 pkgname=('mangohud' 'lib32-mangohud')
-pkgver=0.6.8.r148.g070fa1b
+pkgver=0.6.9
 pkgrel=1
 pkgdesc="Vulkan and OpenGL overlay to display performance information"
 arch=('x86_64')
@@ -11,7 +11,7 @@ depends=('glslang' 'libglvnd' 'lib32-libglvnd' 'glew' 'glfw-x11')
 replaces=('vulkan-mesa-layer-mango')
 license=('MIT')
 source=(
-        "mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#commit=070fa1be842479942b55505688bcb06e86875075"
+        "mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#commit=5fa7087f78e39e92ee4306fdf48fd710960c53dc"
         "mangohud-minhook"::"git+https://github.com/flightlessmango/minhook.git"
         "imgui-v1.81.tar.gz::https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
         "imgui-1.81-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/imgui/1.81/1/get_zip"


### PR DESCRIPTION
This is mainly to get
https://github.com/flightlessmango/MangoHud/commit/a155c10df39ee6d007779ed2ea65d191ff6aa3d7 which fixes a bug with the CPU wattage being shown as 1000x higher than what it actually is on my 6800u.