### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       pull-requests: read
     outputs:
       require-rebuild: ${{ steps.filter.outputs.require-rebuild }}
+      tag-exist: ${{ steps.tagcheck.outputs.exists }}
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -31,11 +32,26 @@ jobs:
               - 'Dockerfile'
               - 'manifest'
               - 'pkgs/**'
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Check if tag exists
+        id: tagcheck
+        run: |
+          if docker manifest inspect ${{ steps.meta.outputs.tags }} >/dev/null; then
+              echo "Tag does exist"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "Tag does not exist"
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build-docker-image:
     name: Build and publish docker container
     needs: changes
-    if: ${{ needs.changes.outputs.require-rebuild == 'true' }}
+    if: ${{ needs.changes.outputs.require-rebuild == 'true' || needs.changes.outputs.tag-exist == 'false'}}
     uses: ./.github/workflows/build.yml
 
   list-pkgbuilds:
@@ -53,7 +69,7 @@ jobs:
     needs:
      - build-docker-image
      - list-pkgbuilds
-    if: ${{ !cancelled() && (success() || failure() || needs.build-docker-image.result == 'skipped') }}
+    if: ${{ !cancelled() && (success() || failure() || needs.build-docker-image.result == 'skipped') && (needs.build-docker-image.result != 'failed') }}
     name: Build AUR package
     runs-on: ubuntu-latest
     strategy:
@@ -81,7 +97,7 @@ jobs:
     needs:
      - build-docker-image
      - aur-pkgbuild
-    if: ${{ !cancelled() && (success() || failure() || needs.build-docker-image.result == 'skipped') }}
+    if: ${{ !cancelled() && (success() || failure() || needs.build-docker-image.result == 'skipped')  && (needs.build-docker-image.result != 'failed') }}
     name: Build ChimeraOS image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I found out that sometimes branches would not create a new docker container. This add a additional check if a container with the tag already exists, otherwise create one.