### PR TITLE
only build intel vulkan driver

### DIFF
--- a/manifest
+++ b/manifest
@@ -64,12 +64,15 @@ export PACKAGES="\
 	lib32-libxcrypt-compat \
 	lib32-libva \
 	lib32-libva-intel-driver \
+	lib32-libva-mesa-driver \
 	lib32-libva-vdpau-driver \
+	lib32-mesa-vdpau \
 	lib32-nvidia-utils \
 	lib32-openal \
 	lib32-pipewire \
 	lib32-systemd \
 	lib32-vulkan-icd-loader \
+	lib32-vulkan-radeon \
 	libcurl-gnutls \
 	libidn11 \
 	libretro-beetle-pce-fast \
@@ -90,6 +93,7 @@ export PACKAGES="\
 	libretro-ppsspp \
 	libretro-snes9x \
 	libva-intel-driver \
+	libva-mesa-driver \
 	libva-vdpau-driver \
 	libxcrypt-compat \
 	lightdm \
@@ -98,6 +102,7 @@ export PACKAGES="\
 	logrotate \
 	lshw \
 	mesa-demos \
+	mesa-vdpau \
 	nano \
 	nautilus \
 	networkmanager \
@@ -130,6 +135,7 @@ export PACKAGES="\
 	usbutils \
 	vim \
 	vulkan-icd-loader \
+	vulkan-radeon \
 	wavpack \
 	which \
 	wireplumber \

--- a/pkgs/00-mesa-anv-gamescope/PKGBUILD
+++ b/pkgs/00-mesa-anv-gamescope/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Andreas Radke <andyrtr@archlinux.org>
 
 pkgbase=mesa-anv-gamescope
-pkgname=('vulkan-mesa-layers-anv-gamescope' 'opencl-mesa-anv-gamescope' 'vulkan-intel-anv-gamescope' 'vulkan-radeon-anv-gamescope' 'vulkan-swrast-anv-gamescope' 'vulkan-virtio-anv-gamescope' 'libva-mesa-driver-anv-gamescope' 'mesa-vdpau-anv-gamescope' 'mesa-anv-gamescope')
+pkgname=('vulkan-intel-anv-gamescope')
 pkgdesc="An open-source implementation of the OpenGL specification"
 pkgver=23.0.2
 pkgrel=2
@@ -69,32 +69,21 @@ build() {
   arch-meson mesa-$pkgver build \
     -D b_ndebug=true \
     -D platforms=x11,wayland \
-    -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink,d3d12 \
-    -D vulkan-drivers=amd,intel,intel_hasvk,swrast,virtio-experimental \
-    -D vulkan-layers=device-select,intel-nullhw,overlay \
+    -D gallium-drivers= \
+    -D vulkan-drivers=intel \
+    -D vulkan-layers= \
     -D dri3=enabled \
-    -D egl=enabled \
-    -D gallium-extra-hud=true \
-    -D gallium-nine=true \
-    -D gallium-omx=bellagio \
-    -D gallium-opencl=icd \
-    -D gallium-va=enabled \
-    -D gallium-vdpau=enabled \
-    -D gallium-xa=enabled \
-    -D gallium-rusticl=true \
-    -D rust_std=2021 \
-    -D gbm=enabled \
+    -D egl=disabled \
+    -D gbm=disabled \
     -D gles1=disabled \
-    -D gles2=enabled \
-    -D glvnd=true \
-    -D glx=dri \
+    -D gles2=disabled \
+    -D glvnd=false \
+    -D glx=disabled \
     -D libunwind=enabled \
     -D llvm=enabled \
-    -D lmsensors=enabled \
-    -D osmesa=true \
-    -D shared-glapi=enabled \
+    -D lmsensors=disabled \
+    -D osmesa=false \
     -D microsoft-clc=disabled \
-    -D video-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
     -D valgrind=enabled
 
   # Print config
@@ -150,6 +139,7 @@ package_vulkan-intel-anv-gamescope() {
   depends=('wayland' 'libx11' 'libxshmfence' 'libdrm' 'zstd' 'systemd-libs')
   optdepends=('vulkan-mesa-layers: additional vulkan layers')
   provides=('vulkan-driver')
+  conflicts=('vulkan-intel')
 
   _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
   _install fakeinstall/usr/lib/libvulkan_intel*.so

--- a/pkgs/01-lib32-mesa-anv-gamescope/PKGBUILD
+++ b/pkgs/01-lib32-mesa-anv-gamescope/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Andreas Radke <andyrtr@archlinux.org>
 
 pkgbase=lib32-mesa-anv-gamescope
-pkgname=('lib32-vulkan-mesa-layers-anv-gamescope' 'lib32-opencl-mesa-anv-gamescope' 'lib32-vulkan-intel-anv-gamescope' 'lib32-vulkan-radeon-anv-gamescope' 'lib32-vulkan-virtio-anv-gamescope' 'lib32-libva-mesa-driver-anv-gamescope' 'lib32-mesa-vdpau-anv-gamescope' 'lib32-mesa-anv-gamescope')
+pkgname=('lib32-vulkan-intel-anv-gamescope')
 pkgdesc="An open-source implementation of the OpenGL specification (32-bit)"
 pkgver=23.0.2
 pkgrel=2
@@ -77,28 +77,20 @@ build() {
     --libdir=/usr/lib32 \
     -D b_ndebug=true \
     -D platforms=x11,wayland \
-    -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink \
-    -D vulkan-drivers=amd,intel,intel_hasvk,virtio-experimental \
-    -D vulkan-layers=device-select,intel-nullhw,overlay \
+    -D gallium-drivers= \
+    -D vulkan-drivers=intel\
+    -D vulkan-layers=\
     -D dri3=enabled \
-    -D egl=enabled \
-    -D gallium-extra-hud=true \
-    -D gallium-nine=true \
-    -D gallium-omx=disabled \
-    -D gallium-opencl=icd \
-    -D gallium-va=enabled \
-    -D gallium-vdpau=enabled \
-    -D gallium-xa=enabled \
-    -D gbm=enabled \
+    -D egl=disabled \
+    -D gbm=disabled \
     -D gles1=disabled \
-    -D gles2=enabled \
-    -D glvnd=true \
-    -D glx=dri \
+    -D gles2=disabled \
+    -D glvnd=false \
+    -D glx=disabled \
     -D libunwind=enabled \
     -D llvm=enabled \
-    -D lmsensors=enabled \
-    -D osmesa=true \
-    -D shared-glapi=enabled \
+    -D lmsensors=disabled \
+    -D osmesa=false \
     -D microsoft-clc=disabled \
     -D video-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
     -D valgrind=disabled
@@ -160,6 +152,7 @@ package_lib32-vulkan-intel-anv-gamescope() {
            'lib32-systemd')
   optdepends=('lib32-vulkan-mesa-layers: additional vulkan layers')
   provides=('lib32-vulkan-driver')
+  conflicts=('lib32-vulkan-intel')
 
   _install fakeinstall/usr/share/vulkan/icd.d/intel_*.json
   _install fakeinstall/usr/lib32/libvulkan_intel*.so


### PR DESCRIPTION
I came across the fact that [valve also uses a seperate radv driver](https://gitlab.com/evlaV/jupiter-PKGBUILD/-/blob/master/mesa-radv/PKGBUILD)

I thought why could we not do the same with our patched intel driver? So I tried this. No idea if it works, so looking for testers :)