### PR TITLE
Add ayaled AUR package

### DIFF
--- a/manifest
+++ b/manifest
@@ -150,6 +150,7 @@ export PACKAGES="\
 "
 
 export AUR_PACKAGES="\
+	ayaled \
 	bcm20702a1-firmware \
 	boxtron \
 	chimera \


### PR DESCRIPTION
Adds ayaled package by Maya Matuszczyk for controlling the ring LED's on the AIR, AIR Pro, 2, and GEEK AYANEO models. Usage instructions are available on the git repo. It provides a web server to change the LED settings over GET requests. This will need to be manually enabled by the user. It comes with some sane defaults but can be customized as the user wants.

https://github.com/Maccraft123/ayaled