### PR TITLE
Remove python-gobject

### DIFF
--- a/manifest
+++ b/manifest
@@ -121,7 +121,6 @@ export PACKAGES="\
 	podman \
 	pulsemixer \
 	python \
-	python-gobject \
 	python-inotify-simple \
 	retroarch \
 	rsync \


### PR DESCRIPTION
Was added as a workaround for pyglet not working with animated splash on chimera. Won't be needed when https://github.com/ChimeraOS/chimera/commit/984a33a2a44052f5144f666de80add8518c7ed23 gets released.