### PR TITLE
Add gnome-tweaks

### DIFF
--- a/manifest
+++ b/manifest
@@ -47,6 +47,7 @@ export PACKAGES="\
 	gnome-shell \
 	gnome-software \
 	gnome-text-editor \
+	gnome-tweaks \
 	gst-plugin-pipewire \
 	haveged \
 	htop \


### PR DESCRIPTION
Gnome-tweaks adds what is missing from the gnome experience that is very useful for users. The ability to enable/disable palm rejection, adjust the minimize/maximize buttons, font sizes, start-up applications and more.

It seems that "Tweaks" is no longer in the flathub ( or never was and my memory fails me...), so this would be the only way to add this without the user unlocking their filesystem.

According to pacman, the installed size is:
Name            : gnome-tweaks
Installed Size  : 1203.48 KiB