### PR TITLE
Update manifest

### DIFF
--- a/manifest
+++ b/manifest
@@ -97,6 +97,7 @@ export PACKAGES="\
 	libva-mesa-driver \
 	libva-vdpau-driver \
 	libxcrypt-compat \
+	libxss \
 	lightdm \
 	linux-firmware \
 	liquidctl \


### PR DESCRIPTION
added libxss

Installed Chimeraos for the first time in a while and was having issues with some gog games (carrion, crosscode, stardew vally) returning the error "no usable version of libssl was found". Appears the version used to build these games was depreciated. There's a unity thread about it that had a fix for Ubuntu. The same issue was present on Arch Linux and installing libxss fixed it so it should fix it for chimeraos. I don't know why it fixed it, but it did 

Idk if I did this exactly right, pastac recommended I do this on the discord 