### PR TITLE
Add symlink to DejaVuSans.ttf for Steam client

### DIFF
--- a/rootfs/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
+++ b/rootfs/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf
@@ -1,0 +1,1 @@
+/usr/share/fonts/TTF/DejaVuSans.ttf


### PR DESCRIPTION
Adding this symlink to allow Steam to bootstrap correctly.

This will allow to remove the current linking of the font done in the gamescope-session PKGBUILD: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=gamescope-session-git#n35