### PR TITLE
Add wget for cryoutilities compatibility

### DIFF
--- a/manifest
+++ b/manifest
@@ -140,6 +140,7 @@ export PACKAGES="\
 	vulkan-icd-loader \
 	vulkan-radeon \
 	wavpack \
+	wget \
 	which \
 	wireplumber \
 	wqy-zenhei \


### PR DESCRIPTION
Cryouilities makes use of wget during the install process.