### PR TITLE
Add tools to update device firmware

### DIFF
--- a/manifest
+++ b/manifest
@@ -44,6 +44,7 @@ export PACKAGES="\
 	gnome-console \
 	gnome-control-center \
 	gnome-disk-utility \
+	gnome-firmware \
 	gnome-keyring \
 	gnome-session \
 	gnome-shell \

--- a/manifest
+++ b/manifest
@@ -39,12 +39,12 @@ export PACKAGES="\
 	fmt \
 	fuse-zip \
 	fuse2 \
+	fwupd \
 	gamemode \
 	git \
 	gnome-console \
 	gnome-control-center \
 	gnome-disk-utility \
-	gnome-firmware \
 	gnome-keyring \
 	gnome-session \
 	gnome-shell \


### PR DESCRIPTION
I noticed that in the current version of Chimera OS is no method present to update device firmware. Therefore I added "gnome-firmware" to the manifest of ChimeraOS. This tool should allow every user from the desktop session to easily and safely update their device firmware. If you do not wan't to include a GUI tool please at least include the underlying "fwupd" tool instad of "gnome-firmware".