### PR TITLE
Remove ryzenadj-controller and don't enable ryzen-tctl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,9 +100,6 @@
 [submodule "aur-pkgs/ryzenadj-git"]
 	path = aur-pkgs/ryzenadj-git
 	url = https://aur.archlinux.org/ryzenadj-git.git
-[submodule "aur-pkgs/ryzenadj-controller-git"]
-	path = aur-pkgs/ryzenadj-controller-git
-	url = https://aur.archlinux.org/ryzenadj-controller-git.git
 [submodule "aur-pkgs/rz608-fix-git"]
 	path = aur-pkgs/rz608-fix-git
 	url = https://aur.archlinux.org/rz608-fix-git.git

--- a/manifest
+++ b/manifest
@@ -191,7 +191,6 @@ export AUR_PACKAGES="\
 	rtl8821au-dkms-git \
 	rtw89-dkms-git \
 	ryzenadj-git \
-	ryzenadj-controller-git \
 	rz608-fix-git \
 	steam-removable-media-git \
 	wyvern \
@@ -210,7 +209,6 @@ export SERVICES="\
 	handycon \
 	haveged \
 	lightdm \
-	ryzenadj-controller \
 	sshd \
 	systemd-timesyncd \
 "
@@ -218,7 +216,6 @@ export SERVICES="\
 export USER_SERVICES="\
 	chimera.service \
 	gamemoded.service \
-	ryzen-tctl \
 	steam-patch.service \
 "
 


### PR DESCRIPTION
python-asyncio recently removed coroutine from the library. This breaks the message handling in ryzenadj-controller. Remove ryzenadj-controller for now until I can be bothered to fix it.