### PR TITLE
Fix only-qam session switching

### DIFF
--- a/rootfs/usr/bin/chimera-session
+++ b/rootfs/usr/bin/chimera-session
@@ -29,7 +29,7 @@ function print_session_list() {
 		CURRENT_SESSION="opengamepadui"
 	fi
 
-	if grep "gamescope-ogui-qam-session" ${SESSION_LIGHTDM_CONFIG} &> /dev/null; then
+	if grep "gamepadui-with-qam-session" ${SESSION_LIGHTDM_CONFIG} &> /dev/null; then
 		CURRENT_SESSION="gamepadui-with-qam"
 	fi
 


### PR DESCRIPTION
This fixes switching to the gamepadui-with-qam session caused by renaming of the service and session.