### PR TITLE
Revert "Downgrade nvidia drivers"

### DIFF
--- a/manifest
+++ b/manifest
@@ -68,6 +68,7 @@ export PACKAGES="\
 	lib32-libva \
 	lib32-libva-intel-driver \
 	lib32-libva-vdpau-driver \
+	lib32-nvidia-utils \
 	lib32-openal \
 	lib32-pipewire \
 	lib32-systemd \
@@ -105,6 +106,9 @@ export PACKAGES="\
 	networkmanager \
 	nfs-utils \
 	nss-mdns \
+	nvidia-dkms \
+	nvidia-prime \
+	nvidia-utils \
 	openal \
 	openssh \
 	pipewire \
@@ -145,10 +149,6 @@ export PACKAGE_OVERRIDES="\
 	https://github.com/ChimeraOS/linux-chimeraos/releases/download/v6.4.4-chos1/linux-chimeraos-6.4.4.chos1-1-x86_64.pkg.tar.zst \
 	https://github.com/ChimeraOS/linux-chimeraos/releases/download/v6.4.4-chos1/linux-chimeraos-headers-6.4.4.chos1-1-x86_64.pkg.tar.zst \
 	https://archive.archlinux.org/repos/2023/06/28/extra/os/x86_64/libretro-pcsx2-11900-2-x86_64.pkg.tar.zst \
-	https://archive.archlinux.org/repos/2023/06/07/extra/os/x86_64/nvidia-dkms-530.41.03-1-x86_64.pkg.tar.zst \
-	https://archive.archlinux.org/repos/2023/06/07/extra/os/x86_64/nvidia-utils-530.41.03-1-x86_64.pkg.tar.zst \
-	https://archive.archlinux.org/repos/2023/06/07/multilib/os/x86_64/lib32-nvidia-utils-530.41.03-1-x86_64.pkg.tar.zst \
-	https://archive.archlinux.org/repos/2023/06/07/extra/os/x86_64/nvidia-prime-1.0-4-any.pkg.tar.zst \
 	https://github.com/ChimeraOS/mesa-chimeraos/releases/download/23.1.3-chos5/lib32-libva-mesa-driver-23.1.3.chos5-1-x86_64.pkg.tar.zst \
 	https://github.com/ChimeraOS/mesa-chimeraos/releases/download/23.1.3-chos5/lib32-mesa-23.1.3.chos5-1-x86_64.pkg.tar.zst \
 	https://github.com/ChimeraOS/mesa-chimeraos/releases/download/23.1.3-chos5/lib32-mesa-vdpau-23.1.3.chos5-1-x86_64.pkg.tar.zst \


### PR DESCRIPTION
This reverts commit 6978095d66b47089d53080ad6c53b4becce8de84.

The module does not work on the latest kernel anyway. Let's see if it does break games on AMD again.

```
dkms install --no-depmod nvidia/530.41.03 -k 6.4.4-chos1-chimeraos-1
Error! Bad return status for module build on kernel: 6.4.4-chos1-chimeraos-1 (x86_64)
```