### PR TITLE
Slim image by not including unused firmwares

### DIFF
--- a/pkgs/50-linux-firmware-git/PKGBUILD
+++ b/pkgs/50-linux-firmware-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=linux-firmware
 pkgname=(linux-firmware-whence linux-firmware amd-ucode
-         linux-firmware-{nfp,mellanox,marvell,qcom,liquidio,qlogic,bnx2x}
+         #linux-firmware-{nfp,mellanox,marvell,qcom,liquidio,qlogic,bnx2x}
 )
 _tag=20230625
 pkgver=20230625.ee91452d


### PR DESCRIPTION
Remove building of
- linux-firmware-nfp
- linux-firmware-mellanox
- linux-firmware-marvell
- linux-firmware-qcom
- linux-firmware-liquidio
- linux-firmware-qlogic
- linux-firmware-bnx2x