### PR TITLE
Add default config for wireplumber

### DIFF
--- a/rootfs/usr/share/wireplumber/main.lua.d/50-alsa-config.lua
+++ b/rootfs/usr/share/wireplumber/main.lua.d/50-alsa-config.lua
@@ -1,0 +1,155 @@
+alsa_monitor.enabled = true
+
+alsa_monitor.properties = {
+  -- Create a JACK device. This is not enabled by default because
+  -- it requires that the PipeWire JACK replacement libraries are
+  -- not used by the session manager, in order to be able to
+  -- connect to the real JACK server.
+  --["alsa.jack-device"] = false,
+
+  -- Reserve devices via org.freedesktop.ReserveDevice1 on D-Bus
+  -- Disable if you are running a system-wide instance, which
+  -- doesn't have access to the D-Bus user session
+  ["alsa.reserve"] = true,
+  --["alsa.reserve.priority"] = -20,
+  --["alsa.reserve.application-name"] = "WirePlumber",
+
+  -- Enables MIDI functionality
+  ["alsa.midi"] = true,
+
+  -- Enables monitoring of alsa MIDI devices
+  ["alsa.midi.monitoring"] = true,
+
+  -- MIDI bridge node properties
+  ["alsa.midi.node-properties"] = {
+    -- Name set for the node with ALSA MIDI ports
+    ["node.name"] = "Midi-Bridge",
+    -- Removes longname/number from MIDI port names
+    --["api.alsa.disable-longname"] = true,
+  },
+
+  -- These properties override node defaults when running in a virtual machine.
+  -- The rules below still override those.
+  ["vm.node.defaults"] = {
+    ["api.alsa.period-size"] = 256,
+    ["api.alsa.headroom"] = 8192,
+  },
+}
+
+alsa_monitor.rules = {
+  -- An array of matches/actions to evaluate.
+  --
+  -- If you want to disable some devices or nodes, you can apply properties per device as the following example.
+  -- The name can be found by running pw-cli ls Device, or pw-cli dump Device
+  --{
+  --  matches = {
+  --    {
+  --      { "device.name", "matches", "name_of_some_disabled_card" },
+  --    },
+  --  },
+  --  apply_properties = {
+  --    ["device.disabled"] = true,
+  --  },
+  --}
+  {
+    -- Rules for matching a device or node. It is an array of
+    -- properties that all need to match the regexp. If any of the
+    -- matches work, the actions are executed for the object.
+    matches = {
+      {
+        -- This matches all cards.
+        { "device.name", "matches", "alsa_card.*" },
+      },
+    },
+    -- Apply properties on the matched object.
+    apply_properties = {
+      -- Use ALSA-Card-Profile devices. They use UCM or the profile
+      -- configuration to configure the device and mixer settings.
+      ["api.alsa.use-acp"] = true,
+
+      -- Use UCM instead of profile when available. Can be
+      -- disabled to skip trying to use the UCM profile.
+      --["api.alsa.use-ucm"] = true,
+
+      -- Don't use the hardware mixer for volume control. It
+      -- will only use software volume. The mixer is still used
+      -- to mute unused paths based on the selected port.
+      --["api.alsa.soft-mixer"] = false,
+
+      -- Ignore decibel settings of the driver. Can be used to
+      -- work around buggy drivers that report wrong values.
+      --["api.alsa.ignore-dB"] = false,
+
+      -- The profile set to use for the device. Usually this is
+      -- "default.conf" but can be changed with a udev rule or here.
+      --["device.profile-set"] = "profileset-name",
+
+      -- The default active profile. Is by default set to "Off".
+      --["device.profile"] = "default profile name",
+
+      -- Automatically select the best profile. This is the
+      -- highest priority available profile. This is disabled
+      -- here and instead implemented in the session manager
+      -- where it can save and load previous preferences.
+      ["api.acp.auto-profile"] = false,
+
+      -- Automatically switch to the highest priority available port.
+      -- This is disabled here and implemented in the session manager instead.
+      ["api.acp.auto-port"] = false,
+
+      -- Other properties can be set here.
+      --["device.nick"] = "My Device",
+    },
+  },
+  {
+    matches = {
+      {
+        -- Matches all sources.
+        { "node.name", "matches", "alsa_input.*" },
+      },
+      {
+        -- Matches all sinks.
+        { "node.name", "matches", "alsa_output.*" },
+      },
+    },
+    apply_properties = {
+      --["node.nick"]              = "My Node",
+      --["node.description"]       = "My Node Description",
+      --["priority.driver"]        = 100,
+      --["priority.session"]       = 100,
+      --["node.pause-on-idle"]     = false,
+      --["monitor.channel-volumes"] = false
+      --["resample.quality"]       = 4,
+      --["resample.disable"]       = false,
+      --["channelmix.normalize"]   = false,
+      --["channelmix.mix-lfe"]     = false,
+      --["channelmix.upmix"]       = true,
+      --["channelmix.upmix-method"] = "psd",  -- "none" or "simple"
+      --["channelmix.lfe-cutoff"]  = 150,
+      --["channelmix.fc-cutoff"]   = 12000,
+      --["channelmix.rear-delay"]  = 12.0,
+      --["channelmix.stereo-widen"] = 0.0,
+      --["channelmix.hilbert-taps"] = 0,
+      --["channelmix.disable"]     = false,
+      --["dither.noise"]           = 0,
+      --["dither.method"]          = "none",  -- "rectangular", "triangular" or "shaped5"
+      --["audio.channels"]         = 2,
+      --["audio.format"]           = "S16LE",
+      --["audio.rate"]             = 44100,
+      --["audio.allowed-rates"]    = "32000,96000",
+      --["audio.position"]         = "FL,FR",
+      --["api.alsa.period-size"]   = 1024,
+      --["api.alsa.period-num"]    = 2,
+      --["api.alsa.headroom"]      = 1024,
+      --["api.alsa.start-delay"]   = 0,
+      --["api.alsa.disable-mmap"]  = false,
+      --["api.alsa.disable-batch"] = false,
+      --["api.alsa.use-chmap"]     = false,
+      --["api.alsa.multirate"]     = true,
+      --["latency.internal.rate"]  = 0
+      --["latency.internal.ns"]    = 0
+      --["clock.name"]             = "api.alsa.0"
+      --["session.suspend-timeout-seconds"] = 0,  -- 0 disables suspend
+    },
+  },
+}


### PR DESCRIPTION
This seems to be beneficial on all devices I've messed with. This won't fix all hardware unfortunately, but it should be a much better default for most hardware configurations when gamescope is being used.
