### PR TITLE
Improve terminal with bash-completion for standard autofill

### DIFF
--- a/manifest
+++ b/manifest
@@ -18,6 +18,7 @@ export PACKAGES="\
 	alsa-firmware \
 	alsa-utils \
 	amd-ucode \
+	bash-completion \
 	broadcom-wl-dkms \
 	cifs-utils \
 	diffutils \


### PR DESCRIPTION
This package massively improves the terminal. It allows for pressing tab to autofill commands, subcommands, and files, just like a normal distro.

Adds ~0.83 MiB

Closes #777