### PR TITLE
Add GNOME System Monitor for easy user process management

### DIFF
--- a/manifest
+++ b/manifest
@@ -46,6 +46,7 @@ export PACKAGES="\
 	gnome-session \
 	gnome-shell \
 	gnome-software \
+	gnome-system-monitor \
 	gnome-text-editor \
 	gst-plugin-pipewire \
 	haveged \


### PR DESCRIPTION
It is essential for desktop users to have the power to manage processes. GNOME System Monitor is easily the best at this, and is a core GNOME app. This PR adds it to improve the general desktop experience.

Adds 14.02 MiB

Closes #765