### PR TITLE
Fix screen recording on Wayland

### DIFF
--- a/manifest
+++ b/manifest
@@ -216,12 +216,12 @@ export SERVICES="\
 	sshd \
 	systemd-timesyncd \
 	swapfile \
-	pipewire \
 "
 
 export USER_SERVICES="\
 	chimera.service \
 	gamemoded.service \
+	pipewire \
 	ryzen-tctl \
 	steam-patch.service \
 "

--- a/manifest
+++ b/manifest
@@ -216,6 +216,7 @@ export SERVICES="\
 	sshd \
 	systemd-timesyncd \
 	swapfile \
+	pipewire \
 "
 
 export USER_SERVICES="\


### PR DESCRIPTION
The `pipewire` module needs to be loaded by the user, elsewise it will break the screen recording entirely on the desktop. Fixes #772