### PR TITLE
Remove File Roller as it duplicates built-in Nautilus functionality (obscolete package)

### DIFF
--- a/manifest
+++ b/manifest
@@ -19,6 +19,7 @@ export PACKAGES="\
 	alsa-utils \
 	amd-ucode \
 	broadcom-wl-dkms \
+	bzip2 \
 	cifs-utils \
 	diffutils \
 	dkms \
@@ -30,6 +31,7 @@ export PACKAGES="\
 	ethtool \
 	evtest \
 	ffmpeg \
+	file \
 	firejail \
 	flatpak \
 	fmt \
@@ -47,6 +49,7 @@ export PACKAGES="\
 	gnome-software \
 	gnome-text-editor \
 	gst-plugin-pipewire \
+	gzip \
 	haveged \
 	htop \
 	intel-gpu-tools \
@@ -94,6 +97,7 @@ export PACKAGES="\
 	linux-firmware \
 	liquidctl \
 	logrotate \
+	lrzip \
 	lshw \
 	mesa-demos \
 	modemmanager \
@@ -121,7 +125,9 @@ export PACKAGES="\
 	sshfs \
 	steam \
 	sudo \
+	tar \
 	ttf-liberation \
+	unace \
 	unrar \
 	unzip \
 	usb_modeswitch \
@@ -139,6 +145,8 @@ export PACKAGES="\
 	xdg-user-dirs-gtk \
 	xf86-video-amdgpu \
 	xorg-server \
+	xz \
+	zip \
 "
 
 export PACKAGE_OVERRIDES="\

--- a/manifest
+++ b/manifest
@@ -30,7 +30,6 @@ export PACKAGES="\
 	ethtool \
 	evtest \
 	ffmpeg \
-	file-roller \
 	firejail \
 	flatpak \
 	fmt \

--- a/manifest
+++ b/manifest
@@ -105,6 +105,7 @@ export PACKAGES="\
 	nss-mdns \
 	openal \
 	openssh \
+	p7zip \
 	pipewire \
 	pipewire-alsa \
 	pipewire-jack \
@@ -121,6 +122,7 @@ export PACKAGES="\
 	steam \
 	sudo \
 	ttf-liberation \
+	unrar \
 	unzip \
 	usb_modeswitch \
 	usbutils \


### PR DESCRIPTION
This PR removes File roller as it is obscolete due to Nautilus natively having both compression and decompression features. Adds duplicate functionality. This cleans up the install a bit.

Also added `p7zip` and `unrar` packages. These serve to allow Nautilus to natively compress and decompress `.7z` and `.rar` files natively.

Frees >=4.11 MiB

![Screenshot from 2023-10-09 18-34-32](https://github.com/ChimeraOS/chimeraos/assets/25536957/5e75501c-a6df-4cc5-9375-055633c48a40)

![Screenshot from 2023-10-09 18-35-46](https://github.com/ChimeraOS/chimeraos/assets/25536957/bd8b016e-69f8-4a3f-a4e3-d6a3e1261dbb)
![Screenshot from 2023-10-09 18-37-28](https://github.com/ChimeraOS/chimeraos/assets/25536957/5526059e-260d-4a13-8fb2-3efda6bef64b)
