### PR TITLE
Enable video thumbnail previews in file manager

### DIFF
--- a/manifest
+++ b/manifest
@@ -30,6 +30,7 @@ export PACKAGES="\
 	ethtool \
 	evtest \
 	ffmpeg \
+	ffmpegthumbnailer \
 	file-roller \
 	firejail \
 	flatpak \


### PR DESCRIPTION
This PR adds only 0.26 MiB of size. It allows the Nautilus file manager to generate video thumbnails. You could imagine this being nice especially for Discord users, for instance.

Before:

![Screenshot from 2023-10-11 00-57-32](https://github.com/ChimeraOS/chimeraos/assets/25536957/d953a291-c9b6-4274-bb71-d6794a001cf1)

After:

![Screenshot from 2023-10-11 00-56-44](https://github.com/ChimeraOS/chimeraos/assets/25536957/e4c2f348-96f0-41cd-bd9a-daf7fcde5b48)

Size:

![image](https://github.com/ChimeraOS/chimeraos/assets/25536957/a5cf5532-3e75-4920-906e-15bafc4dce7f)
