### PR TITLE
Replace legacy image viewer with official modern GNOME image viewer

### DIFF
--- a/manifest
+++ b/manifest
@@ -25,7 +25,6 @@ export PACKAGES="\
 	distrobox \
 	dmidecode \
 	dosbox \
-	eog \
 	epiphany \
 	ethtool \
 	evtest \
@@ -95,6 +94,7 @@ export PACKAGES="\
 	linux-firmware \
 	liquidctl \
 	logrotate \
+	loupe \
 	lshw \
 	mesa-demos \
 	modemmanager \


### PR DESCRIPTION
ChimeraOS currently ships Eye of GNOME (eog) as it's default image viewer. Eye of GNOME is unmaintained, deprecated, and has officially been replaced with the modern GTK4 image viewer called Loupe. This newer application is more stable, has better features, looks nicer, and is based on the modern LibAdwaita UI. It would be better for ChimeraOS, too, as it has far superior touch features, making it the ideal image viewer for touchscreen devices such as handhelds.

There are also security and performance improvements compared to Eye of GNOME, as well as more accurate SVG rendering and more supported formats.

![Screenshot from 2023-10-12 10-39-11](https://github.com/ChimeraOS/chimeraos/assets/25536957/f115cb68-ecbb-4a5f-886c-ac658ac4fb46)

![Screenshot from 2023-10-12 10-41-44](https://github.com/ChimeraOS/chimeraos/assets/25536957/153594bc-2a90-4ce9-8d57-bf63ed49ae1e)

![Screenshot from 2023-10-12 10-39-36](https://github.com/ChimeraOS/chimeraos/assets/25536957/c4d84a63-faca-429c-bce1-8fc78c1ef771)

