### PR TITLE
Adds less and tree.

### DIFF
--- a/manifest
+++ b/manifest
@@ -59,6 +59,7 @@ export PACKAGES="\
 	intel-media-driver \
 	intel-ucode \
 	intel-undervolt \
+	less \
 	lib32-curl \
 	lib32-fontconfig \
 	lib32-freetype2 \
@@ -130,6 +131,7 @@ export PACKAGES="\
 	steam \
 	sudo \
 	tar \
+	tree \
 	ttf-liberation \
 	unace \
 	unrar \


### PR DESCRIPTION
At some point one of our packages dropped less as an explicit dependency. This adds it back. Also included is tree which I use every day while developing.

```
sudo pacman -Sy less
Package (1)   New Version  Net Change

core/less   1:643-1        0.28 MiB

Total Installed Size:  0.28 MiB
```
```
sudo pacman -Sy tree
Package (1)  New Version  Net Change

extra/tree   2.1.1-1        0.09 MiB

Total Installed Size:  0.09 MiB
```