### PR TITLE
Tailscale 

### DIFF
--- a/manifest
+++ b/manifest
@@ -131,6 +131,7 @@ export PACKAGES="\
 	sshfs \
 	steam \
 	sudo \
+	tailscale \
 	tar \
 	tree \
 	ttf-liberation \


### PR DESCRIPTION
Tailscale+Syncthing is a very common stack for syncing files between computers and it works very well for syncing saves between a Steam Deck and a Gaming PC over LAN or WAN. 

I had a lot of trouble trying to get Tailscale to run as a systemd user level service, and ideally Tailscale would be running as root so it can make the necessary networking changes.

This simply installs Tailscale enabling quick and easy setup.

Install command for testing:
```
sudo frzr-deploy diericx/chimeraos:unstable
```