### PR TITLE
Add antimicrox to map gamepad to kbm inputs

### DIFF
--- a/manifest
+++ b/manifest
@@ -177,6 +177,7 @@ export PACKAGE_OVERRIDES="\
 # Which is often the same as the package name but it can be different.
 # Check on the AUR webpage if you are unsure
 export AUR_PACKAGES="\
+	antimicrox \
 	ayaled \
 	ayn-platform-dkms-git \
 	bcm20702a1-firmware \


### PR DESCRIPTION
This utility should prove very useful for mapping any gamepad to control the keyboard and mouse events when using the desktop. It supports profiles that can be created so any gamepad should easily be configurable including external controllers.

More importantly this utility supports Wayland which up to this day the Steam Input solution does not support.