### PR TITLE
Disable amd_pstates by default

### DIFF
--- a/rootfs/usr/lib/frzr.d/bootconfig.conf
+++ b/rootfs/usr/lib/frzr.d/bootconfig.conf
@@ -1,1 +1,1 @@
-ibt=off split_lock_detect=off iomem=relaxed nowatchdog
+amd_pstate=disable ibt=off split_lock_detect=off iomem=relaxed nowatchdog


### PR DESCRIPTION
The experience with pstates has been very inconsistent and usually results in the CPU being set to maximum frequency even when it's not needed. Some devices have the opposite problem where the CPU will scale down to the lowest possible frequency no matter what. I'm sure some devices may benefit from pstates, but with my testing I don't see that being the majority.

The kernel tries to default to amd-pstate-epp on the 5800U devices and it's much worse than using apcifreq.