### PR TITLE
Add AUR Package Build Exit Code Check

### DIFF
--- a/aur-pkgs/build-aur-package.sh
+++ b/aur-pkgs/build-aur-package.sh
@@ -14,5 +14,10 @@ git clone --depth=1 https://aur.archlinux.org/${1}.git /temp/package
 PIKAUR_CMD="PKGDEST=/workdir/aur-pkgs pikaur --noconfirm --build-gpgdir /etc/pacman.d/gnupg -S -P /temp/package/PKGBUILD"
 PIKAUR_RUN=(bash -c "${PIKAUR_CMD}")
 "${PIKAUR_RUN[@]}"
+# if aur package is not successfully built, exit
+if [ $? -ne 0 ]; then
+    echo "Build failed. Stopping..."
+    exit -1
+fi
 # remove any epoch (:) in name, replace with -- since not allowed in artifacts
 find /workdir/aur-pkgs/*.pkg.tar* -type f -name '*:*' -execdir bash -c 'mv "$1" "${1//:/--}"' bash {} \;


### PR DESCRIPTION
To prevent failed build task continuing, introduce exit code check.

Example:
<https://github.com/ChimeraOS/chimeraos/actions/runs/7939157980/job/21682894843>
This job failed to package but the whole task still continued.