### PR TITLE
Replace Ardour with Qtractor

### DIFF
--- a/manifest
+++ b/manifest
@@ -125,6 +125,7 @@ export PACKAGES="\
 	pulsemixer \
 	python \
 	python-inotify-simple \
+	qtractor \
 	retroarch \
 	rsync \
 	smbclient \


### PR DESCRIPTION
This allows sparing more than 100MB of space on the final resulting image while retaining the needed ladspa-host functionality required by chimera quirks package to make some hardware work correctly.

Since I don't own such hardware I couldn't test if the substitution works as intended: someone has to try that before merging this PR.