### PR TITLE
Add xrandr to mangohud dependencies

### DIFF
--- a/pkgs/mangohud/PKGBUILD
+++ b/pkgs/mangohud/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 makedepends=('dbus' 'gcc' 'meson' 'python-mako' 'libx11' 'lib32-libx11' 'git' 'pkgconf' 'vulkan-headers' 'appstream'
              'libxnvctrl'
 )
-depends=('glslang' 'libglvnd' 'lib32-libglvnd' 'glew' 'glfw-x11')
+depends=('glslang' 'libglvnd' 'lib32-libglvnd' 'glew' 'glfw-x11' 'libxrandr')
 replaces=('vulkan-mesa-layer-mango')
 license=('MIT')
 _commit=dc60dc71ec3e7b87fdab3c8bacfd794404e24ab5 # 0.7.1.rc2


### PR DESCRIPTION
Attempting to build mangohud in a clean chroot with no libxrandr fails as it's missing some needed headers.

Add libxrandr as a dependency.