### PR TITLE
Remove bmi260 DKMS

### DIFF
--- a/manifest
+++ b/manifest
@@ -189,7 +189,6 @@ export AUR_PACKAGES="\
 	ayaneo-platform-dkms-git \
 	ayn-platform-dkms-git \
 	bcm20702a1-firmware \
-  	bmi260-dkms \
 	boxtron \
 	chimera \
 	chimeraos-device-quirks-git \


### PR DESCRIPTION
Removes BMI260 DKMS module in favor of using a kernel patch directly.