### PR TITLE
Add evdev-keepalive

### DIFF
--- a/manifest
+++ b/manifest
@@ -32,6 +32,7 @@ export PACKAGES="\
 	efibootmgr \
 	epiphany \
 	ethtool \
+        evdev-keepalive \
 	evtest \
 	ffmpeg \
 	file \


### PR DESCRIPTION
Adds evdev-keepalive udev service. This works around an issue with some AYANEO devices and other 8BitDo controllers which will either sleep randomly or continuously restart themselves when they aren't grabbed by a process. This causes some devices to repeatedly vibrate during boot or never fully intialize the xpad driver.