### PR TITLE
razer: allow control of such hardware

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -125,7 +125,7 @@ passwd --lock root
 
 # create user
 groupadd -r autologin
-useradd -m ${USERNAME} -G autologin,wheel
+useradd -m ${USERNAME} -G autologin,wheel,plugdev
 echo "${USERNAME}:${USERNAME}" | chpasswd
 
 # set the default editor, so visudo works

--- a/manifest
+++ b/manifest
@@ -115,6 +115,7 @@ export PACKAGES="\
 	noto-fonts-emoji \
 	nss-mdns \
 	openal \
+	openrazer-daemon \
 	openssh \
 	p7zip \
 	pipewire \
@@ -125,6 +126,7 @@ export PACKAGES="\
 	pulsemixer \
 	python \
 	python-inotify-simple \
+	python-notify2 \
 	retroarch \
 	rsync \
 	smbclient \


### PR DESCRIPTION
Razer is well-known into desktop PC gaming and also makes some latops. Add the required dkms kernel module and daemon to allow configuring those devices. Multiple frontends are available for the user to choose from and none is included.