### PR TITLE
mkinitcpio: add microcode hook

### DIFF
--- a/rootfs/etc/mkinitcpio.conf
+++ b/rootfs/etc/mkinitcpio.conf
@@ -3,4 +3,4 @@
 MODULES=(dm_mod ext4 sha256 sha512 overlay)
 BINARIES=()
 FILES=()
-HOOKS=(base udev modconf kms block keyboard keymap filesystems fsck frzr-etc)
+HOOKS=(base microcode udev modconf kms block keyboard keymap filesystems fsck frzr-etc)


### PR DESCRIPTION
Archlinux switched to including microcode in the initramfs as the preferred method to load amd-ucode.img and intel-ucode.img and also deprecated using initrd options on the bootloader.