### PR TITLE
mkinitcpio: compress the image with xz

### DIFF
--- a/rootfs/etc/mkinitcpio.conf
+++ b/rootfs/etc/mkinitcpio.conf
@@ -4,3 +4,5 @@ MODULES=(dm_mod ext4 sha256 sha512 overlay)
 BINARIES=()
 FILES=()
 HOOKS=(base udev modconf kms block keyboard keymap filesystems fsck frzr-etc)
+COMPRESSION="xz"
+COMPRESSION_OPTIONS=(-v -9e)


### PR DESCRIPTION
The compression algorithm did not make any difference in my tests regarding boot times, but it decreases the size of a file meant to be copied at least one, and potentially two, times to the 512MiB vfat partition.

Having current initramfs taking up too much space clashes with the "easy kernel swaping" feature to be implemented.