### PR TITLE
mkinitcpio: use systemd in initramfs

### DIFF
--- a/rootfs/etc/mkinitcpio.conf
+++ b/rootfs/etc/mkinitcpio.conf
@@ -3,4 +3,4 @@
 MODULES=(dm_mod ext4 sha256 sha512 overlay)
 BINARIES=()
 FILES=()
-HOOKS=(base udev modconf kms block keyboard keymap filesystems fsck frzr-etc)
+HOOKS=(base systemd udev modconf kms block sd-vconsole keyboard keymap filesystems fsck frzr-etc)

--- a/rootfs/etc/vconsole.conf
+++ b/rootfs/etc/vconsole.conf
@@ -1,0 +1,7 @@
+# keyboard keymap in initramfs: get the list of supported keymaps using:
+# localectl keymap-list
+KEYMAP=us
+
+# console font in initramfs: get the list of supported fonts using:
+# ls -l /usr/share/kbd/consolefonts/ | grep -i ".psfu.gz"
+FONT=iso01-12x22


### PR DESCRIPTION
Add systemd in initramfs: this changes the old init program with systemd and also provides a default keymap and font for default initramfs images.