### PR TITLE
mkinitcpio: use systemd and adapt /etc/fstab

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -151,11 +151,10 @@ Subsystem	sftp	/usr/lib/ssh/sftp-server
 " > /etc/ssh/sshd_config
 
 echo "
-LABEL=frzr_root /          btrfs subvol=deployments/${SYSTEM_NAME}-${VERSION},ro,noatime,nodatacow 0 0
-LABEL=frzr_root /var       btrfs subvol=var,rw,noatime,nodatacow 0 0
-LABEL=frzr_root /home      btrfs subvol=home,rw,noatime,nodatacow 0 0
-LABEL=frzr_root /frzr_root btrfs subvol=/,rw,noatime,nodatacow 0 0
-LABEL=frzr_efi  /boot      vfat  rw,noatime,nofail  0 0
+LABEL=frzr_root /var       btrfs     defaults,subvolid=256,rw,noatime,nodatacow                                                                           0   0
+LABEL=frzr_root /home      btrfs     defaults,subvolid=257,rw,noatime,nodatacow                                                                           0   0
+LABEL=frzr_root /frzr_root btrfs     defaults,subvolid=5,rw,noatime,nodatacow,x-initrd                                                                    0   2
+overlayfs       /etc       overlayfs defaults,x-depends-on=/frzr_root,lowerdir=/etc,upperdir=/frzr_root/etc,workdir=/frzr_root/.etc,comment=etcoverlay    0   2
 " > /etc/fstab
 
 echo "
@@ -208,9 +207,10 @@ rm -rf \
 rm -rf ${FILES_TO_DELETE}
 
 # create necessary directories
-mkdir /home
-mkdir /var
-mkdir /frzr_root
+mkdir -p /home
+mkdir -p /var
+mkdir -p /frzr_root
+mkdir -p /efi
 EOF
 
 #defrag the image

--- a/rootfs/etc/mkinitcpio.conf
+++ b/rootfs/etc/mkinitcpio.conf
@@ -3,6 +3,6 @@
 MODULES=(dm_mod ext4 sha256 sha512 overlay)
 BINARIES=()
 FILES=()
-HOOKS=(base microcode udev modconf kms block keyboard keymap filesystems fsck frzr-etc)
+HOOKS=(microcode systemd modconf kms keyboard sd-vconsole block filesystems fsck)
 COMPRESSION="xz"
 COMPRESSION_OPTIONS=(-v -9e)

--- a/rootfs/etc/vconsole.conf
+++ b/rootfs/etc/vconsole.conf
@@ -1,0 +1,7 @@
+# keyboard keymap in initramfs: get the list of supported keymaps using:
+# localectl keymap-list
+KEYMAP=us
+
+# console font in initramfs: get the list of supported fonts using:
+# ls -l /usr/share/kbd/consolefonts/ | grep -i ".psfu.gz"
+FONT=iso01-12x22


### PR DESCRIPTION
Use systemd on initrd instead of busybox to solve two bugs:
- when two chimeraos are installed booting a device might result in mounting the rootfs of the other device
- Issue #919 https://github.com/ChimeraOS/chimeraos/issues/919

/efi will be automounted by systemd: remove the fstab entry.

If the default subvolume of / is changed boot will fail: fix this by mentioning subvolumes by theirs ID (fixed since installation).

This superceedes https://github.com/ChimeraOS/chimeraos/pull/901 and https://github.com/ChimeraOS/chimeraos/pull/914