### PR TITLE
Disable copy-on-write for /home

### DIFF
--- a/rootfs/usr/lib/frzr.d/disable-home-cow.migration
+++ b/rootfs/usr/lib/frzr.d/disable-home-cow.migration
@@ -1,0 +1,9 @@
+# Disable CoW on home directory
+post_install() {
+    if [ -d /home ]; then
+        if ! lsattr /home | grep -Fqx 'C'; then
+            echo "Disabling copy-on-write for /home"
+            chattr +C -R /home 2> /home/.chattr_stderr.txt 1> .chattr_stdout.txt
+        fi
+    fi
+}

--- a/rootfs/usr/lib/frzr.d/install-0011-disable-home-cow.migration
+++ b/rootfs/usr/lib/frzr.d/install-0011-disable-home-cow.migration
@@ -2,8 +2,8 @@
 post_install() {
     if [ -d /home ]; then
         if ! lsattr /home | grep -Fqx 'C'; then
-            echo "Disabling copy-on-write for /home"
             chattr +C -R /home 2> /home/.chattr_stderr.txt 1> .chattr_stdout.txt
+            echo "OK"
         fi
     fi
 }


### PR DESCRIPTION
The rest of the system benefits from copy-on-write: snapshot that are restored (and can be checked) by frzr, compression that got enabled at creation-time, file checksums to ensure integrity.

/home and /var do not benefit from CoW however, they might host frequently-written files, potentially even a VM disk: disable CoW for /home so that it can be mounted without nodatacow.