### PR TITLE
Add ntfs-3g to packages

### DIFF
--- a/manifest
+++ b/manifest
@@ -115,6 +115,7 @@ export PACKAGES="\
 	nfs-utils \
 	noto-fonts-emoji \
 	nss-mdns \
+        ntfs-3g \
 	openal \
 	openrazer-daemon \
 	openssh \


### PR DESCRIPTION
Most of the users who use some kind of external hard drive have them formatted to ntfs. Adding the following package will allow users to use external hard drives for storing games, media and allowing transfer of files from windows PC's.