### PR TITLE
Use nftables instead of the deprecated iptables

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -114,6 +114,14 @@ rm -rf /var/cache/pacman/pkg
 pacman --noconfirm -U --overwrite '*' /extra_pkgs/*
 rm -rf /var/cache/pacman/pkg
 
+# Install the new iptables
+# See https://gitlab.archlinux.org/archlinux/packaging/packages/iptables/-/issues/1
+# Since base package group adds iptables by default
+# pacman will ask for confirmation to replace that package
+# but the default answer is no.
+# doing yes | pacman omitting --noconfirm is a necessity 
+yes | pacman -S iptables-nft
+
 # enable services
 systemctl enable ${SERVICES}
 

--- a/manifest
+++ b/manifest
@@ -267,9 +267,6 @@ export FILES_TO_DELETE="\
 "
 
 postinstallhook() {
-	# use nftables instead of the deprecated iptables
-	yes | pacman -S iptables-nft
-
 	# Add sudo permissions
 	sed -i '/%wheel ALL=(ALL:ALL) ALL/s/^# //g' /etc/sudoers
 	echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/dmidecode -t 11

--- a/manifest
+++ b/manifest
@@ -267,6 +267,9 @@ export FILES_TO_DELETE="\
 "
 
 postinstallhook() {
+	# use nftables instead of the deprecated iptables
+	yes | pacman -S iptables-nft
+
 	# Add sudo permissions
 	sed -i '/%wheel ALL=(ALL:ALL) ALL/s/^# //g' /etc/sudoers
 	echo "${USERNAME} ALL=(ALL) NOPASSWD: /usr/bin/dmidecode -t 11


### PR DESCRIPTION
As per title: use iptables-nft instead of the deprecated iptables.

See https://gitlab.archlinux.org/archlinux/packaging/packages/iptables/-/issues/1 for more details.

The deprecated iptables is not completely suitable for docker or podman as stated in that page.

The reason this is not in PACKAGES is the following error will appear:

```
error: unresolvable package conflicts detected
:: iptables-nft-1:1.8.10-1 and iptables-1:1.8.10-1 are in conflict. Remove iptables? [y/N] 
:: iptables-nft-1:1.8.10-1 and iptables-1:1.8.10-1 are in conflict
error: failed to prepare transaction (conflicting dependencies)
```
