### PR TITLE
Add steam-powerbuttond-git

### DIFF
--- a/manifest
+++ b/manifest
@@ -230,6 +230,7 @@ export AUR_PACKAGES="\
 	rtl8821au-dkms-git \
 	ryzenadj-git \
 	steam_notif_daemon \
+        steam-powerbuttond-git \
 	steam-removable-media-git \
 	wyvern \
 	zenergy-dkms-git \
@@ -246,6 +247,7 @@ export SERVICES="\
 	inputplumber \
 	lightdm \
 	powerstation \
+        steam-powerbuttond \
 	sshd \
 	systemd-timesyncd \
 	swapfile \


### PR DESCRIPTION
Replaces the functionality of the steam suspend feature that HandyGCCS provided in an input manager agnostic way.