### PR TITLE
Add lib32-sdl2 for native 32 bit Linux games

### DIFF
--- a/manifest
+++ b/manifest
@@ -77,6 +77,7 @@ export PACKAGES="\
 	lib32-libva-vdpau-driver \
 	lib32-openal \
 	lib32-pipewire \
+	lib32-sdl2 \
 	lib32-systemd \
 	lib32-vulkan-icd-loader \
 	libcurl-gnutls \


### PR DESCRIPTION
The package adds support for 32 bit SDL and is needed by some older native games, like "Portal Stories: Mel".
It adds slightly over 2 MB in size.