### PR TITLE
fix: Disable btrfs compression to make swapon work

### DIFF
--- a/rootfs/usr/bin/mkswapfile
+++ b/rootfs/usr/bin/mkswapfile
@@ -27,6 +27,9 @@ usage() { echo >&2 "Usage: $(basename $0) FILE SIZE"; exit 1; }
 
 [ -e "$SWAPFILE" ] && fail "File '$SWAPFILE' already exists"
 
+touch "$SWAPFILE"
+chattr +C "$SWAPFILE"
+btrfs property set "$SWAPFILE" compression none
 dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAPSIZE"
 chmod 600 "$SWAPFILE"
 mkswap "$SWAPFILE"


### PR DESCRIPTION
Since btrfs compression of system image enabled by default, swapfile has been broken.

Here is log:
```
$ systemctl status home-swapfile.swap
× home-swapfile.swap - Swap
     Loaded: loaded (/etc/systemd/system/home-swapfile.swap; enabled; preset: disabled)
     Active: failed (Result: exit-code) since Tue 2024-04-30 20:57:21 CST; 2h 20min ago
       What: /home/swapfile
        CPU: 8ms

Apr 30 20:57:21 chimeros systemd[1]: Activating swap Swap...
Apr 30 20:57:21 chimeros swapon[486]: swapon: /home/swapfile: swapon failed: Invalid argument
Apr 30 20:57:21 chimeros systemd[1]: home-swapfile.swap: Swap process exited, code=exited, status=255/EXCEPTION
```

This pull request means to solve this problem.