### PR TITLE
Add Gnome Tweaks app to the manifest.

### DIFF
--- a/manifest
+++ b/manifest
@@ -54,6 +54,7 @@ export PACKAGES="\
 	gnome-software \
 	gnome-system-monitor \
 	gnome-text-editor \
+	gnome-tweaks \
 	gst-plugin-pipewire \
 	gvfs-smb \
 	gvfs-nfs \


### PR DESCRIPTION
Allows certain tweaks like minimize/maximize buttons on windows without having to use gsettings manually.