### PR TITLE
Attempt to add Nvidia support back

### DIFF
--- a/manifest
+++ b/manifest
@@ -121,6 +121,12 @@ export PACKAGES="\
 	nfs-utils \
 	noto-fonts-emoji \
 	nss-mdns \
+	nvidia \
+	opencl-nvidia \
+	lib32-opencl-nvidia \
+	nvidia-utils \
+	lib32-nvidia-utils \
+	nvidia-prime \
 	openal \
 	openrazer-daemon \
 	openssh \


### PR DESCRIPTION
The explicit sync support has hit stable with the Nvidia drivers and it is now possible for us to begin to support Nvidia again.