### PR TITLE
Fix installation in non-nvme and non-mmcblk device types

### DIFF
--- a/rootfs/usr/lib/frzr.d/install-0003-root_part_gpt.migration
+++ b/rootfs/usr/lib/frzr.d/install-0003-root_part_gpt.migration
@@ -23,16 +23,17 @@ post_install() {
     echo "Fetching partition number of partition '$subcmd'"
     local part_number=$(echo "${subcmd: -1}")
 
-    local disk=$(echo "$subcmd" | sed 's/p[0-9]*$//')
+    local disk=$(echo "$subcmd" | sed -E 's/p[0-9]+$|[0-9]+$//')
     local filtered_uuid=$(echo "${possible_uuid}" | grep -E '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}')
 
     echo "Setting partition ${part_number} of disk ${disk} (UUID='${filtered_uuid}') to GPT type 'Linux Root (x86-64)'"
 
     if [ -z $filtered_uuid ] || [ -z $subcmd ] || [ -z part_number ] || [ -z disk ]; then
-        echo "Error retrieving the rootfs UUID: ${rootfs_uuid}"
+        echo "ERROR: Could not retrieve the rootfs UUID: ${rootfs_uuid}"
         exit 1
     else
         echo "Writing the correct GPT type to the partition ${part_number} of disk ${disk}"
         parted --script "${disk}" type "${part_number}" "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
+        echo "OK"
     fi
 }


### PR DESCRIPTION
The installation was failing from devices like /dev/sda but was working on /dev/nvme and /dev/mmcblk disks due to a wrong regex used to extract the disk from the partition.