### PR TITLE
Move the whole pacman directory

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -209,8 +209,8 @@ postinstallhook
 pacman -Q > /manifest
 
 # preserve installed package database
-mkdir -p /usr/var/lib/pacman
-cp -a /var/lib/pacman/local /usr/var/lib/pacman/
+mkdir -p /usr/var/lib/
+mv /var/lib/pacman /usr/var/lib/
 
 # Remove the fallback: it is never used and takes up space
 if [ -e "/boot/initramfs-${KERNEL_PACKAGE}-fallback.img" ]; then

--- a/rootfs/usr/lib/frzr.d/unlock-0002-pacman-db.unlock
+++ b/rootfs/usr/lib/frzr.d/unlock-0002-pacman-db.unlock
@@ -15,10 +15,10 @@ post_unlock() {
     SUBVOL_DATA="${DEPLOYMENT_DATA}/${NAME}"
 
     if [ -d "${SUBVOL_DATA}/var_overlay/upperdir" ]; then
-        if cp -a "${SUBVOL}/usr/var/lib/pacman/local" "${SUBVOL_DATA}/var_overlay/upperdir/lib/pacman/"; then
+        if cp -a "${SUBVOL}/usr/var/lib/pacman" "${SUBVOL_DATA}/var_overlay/upperdir/lib/"; then
             echo "OK"
         else
-            echo "ERROR: Could not copy the pacman database at '${SUBVOL_DATA}/var_overlay/upperdir/lib/pacman'"
+            echo "ERROR: Could not copy the pacman database at '${SUBVOL_DATA}/var_overlay/upperdir/lib/'"
         fi
     else
         echo "ERROR: Could not find the /var overlay directory '${SUBVOL_DATA}/var_overlay/upperdir'"    


### PR DESCRIPTION
To avoid database inconsistencies and retain the correct behavior of having pacman reporting the missing database move the whole pacman directory as before changes to adapt to the refactored frzr.