### PR TITLE
Move udev rules

### DIFF
--- a/manifest
+++ b/manifest
@@ -31,7 +31,6 @@ export PACKAGES="\
 	dosbox \
 	efibootmgr \
 	epiphany \
-	ethtool \
 	evtest \
 	fakeroot \
 	ffmpeg \

--- a/manifest
+++ b/manifest
@@ -287,13 +287,6 @@ postinstallhook() {
 	${USERNAME} ALL=(ALL) NOPASSWD: /usr/share/chimera/bin/power-tool
 	" >/etc/sudoers.d/chimera
 
-	# download and add racing wheel udev rules
-	pushd /usr/lib/udev/rules.d
-	curl -L -O https://raw.githubusercontent.com/berarma/oversteer/master/data/udev/99-fanatec-wheel-perms.rules
-	curl -L -O https://raw.githubusercontent.com/berarma/oversteer/master/data/udev/99-logitech-wheel-perms.rules
-	curl -L -O https://raw.githubusercontent.com/berarma/oversteer/master/data/udev/99-thrustmaster-wheel-perms.rules
-	popd
-
 	# Remove build tools for slimmer image
 	rm /usr/share/libalpm/hooks/70-dkms-install.hook
 	rm /usr/share/libalpm/hooks/70-dkms-upgrade.hook

--- a/rootfs/etc/udev/rules.d/00-ntfs3-default-mount.rules
+++ b/rootfs/etc/udev/rules.d/00-ntfs3-default-mount.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"

--- a/rootfs/etc/udev/rules.d/81-wol.rules
+++ b/rootfs/etc/udev/rules.d/81-wol.rules
@@ -1,1 +1,0 @@
-ACTION=="add", SUBSYSTEM=="net", NAME=="enp*", RUN+="/usr/bin/ethtool -s $name wol g"


### PR DESCRIPTION
This PR moves udev rules and additional dependencies for those udev rules into device-quirks package. 

Also accomplish what is requested here: https://github.com/ChimeraOS/device-quirks/pull/114