### PR TITLE
ZSTD issue with CI

### DIFF
--- a/manifest
+++ b/manifest
@@ -170,6 +170,7 @@ export PACKAGES="\
 	xorg-server \
 	xz \
 	zip \
+        zstd \
 "
 
 export PACKAGE_OVERRIDES="\


### PR DESCRIPTION
Missing dependency zstd, needed by gamescope apparently