### PR TITLE
Bluetooth auto reconnect service

### DIFF
--- a/manifest
+++ b/manifest
@@ -249,6 +249,7 @@ export SERVICES="\
 	NetworkManager \
 	avahi-daemon \
 	bluetooth \
+	bluetooth-auto-connect \
 	bluetooth-workaround \
 	fstrim.timer \
 	haveged \

--- a/rootfs/etc/systemd/system/bluetooth-auto-connect.service
+++ b/rootfs/etc/systemd/system/bluetooth-auto-connect.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=A service that periodicaly scan & connect for previously connected bluetooth devices
+After=bluetooth.service
+
+[Service]
+ExecStart=/usr/bin/bluetoothctl -t 3 scan on
+Restart=Always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Motivation

Hi, after installing ChimeraOS, I was unable to connect my Xbox Series controller until I navigated to the bluetooth settings. It was very similar to [this issue](https://github.com/ChimeraOS/chimeraos/issues/556)

# Investigation

After searching the cause of this problem, it seems that a Bluetooth scan was triggered while navigating to the Gnome Bluetooth Settings, and disabled when leaving that page.  

Later, I was able to reconnect my controller by using the command `bluetoothctl -t -1 scan on` without navigating to the bluetooth settings

# Solution

This PR add a simple systemd service that periodically scan for previously connected Bluetooth devices

I am now able to automatically reconnect my controller in the following cases : 
- On startup even before the session is loaded
- When I unplug & replug my bluetooth dongle
- When my controller is disconnected due to idle or battery and I press the guide button

# Mention

It seems that Bluez allow for periodic scans in the config via `ScanIntervalAutoConnect` & `ScanWindowAutoConnect` parameters ([link](https://github.com/Vudentz/BlueZ/blob/master/src/main.conf)).

This could be a way cleaner solution, but I was unable to make them work.

# Hardware & Software

- Xbox Series Official Wireless Controller
- my bluetooth dongle (https://www.amazon.fr/dp/B09TT7SXHY?ref=ppx_yo2ov_dt_b_fed_asin_title)
- NVidia Geforce 1080TI
- ChimeraOS 47 (b88d2bf) [UNSTABLE]

# Note

This is my first PR for Chimera so I may not have respected some design & architectural choice