### PR TITLE
Disable check and debug for makepkg on the final image

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -94,6 +94,10 @@ sed -i '/CheckSpace/s/^/#/g' /etc/pacman.conf
 # update package databases
 pacman --noconfirm -Syy
 
+# Disable check and debug for makepkg on the final image
+sed -i '/BUILDENV/s/ check/ !check/g' /etc/makepkg.conf
+sed -i '/OPTIONS/s/ debug/ !debug/g' /etc/makepkg.conf
+
 # install kernel package
 if [ "$KERNEL_PACKAGE_ORIGIN" == "local" ] ; then
 	pacman --noconfirm -U --overwrite '*' \


### PR DESCRIPTION
Check and debug both increase the build time for package, while debug also increase size for no benefit as chimera does not ship with a debugger and people don't use one on system software anyway: remove both options.