### PR TITLE
Change nvidia-dkms to nvidia-open-dkms

### DIFF
--- a/manifest
+++ b/manifest
@@ -121,7 +121,7 @@ export PACKAGES="\
 	nfs-utils \
 	noto-fonts-emoji \
 	nss-mdns \
-	nvidia-dkms \
+	nvidia-open-dkms \
 	opencl-nvidia \
 	lib32-opencl-nvidia \
 	nvidia-utils \


### PR DESCRIPTION
The package nvidia-open-dkms is the suggested option by both archlinux and nvidia. It works generally better.
It supports nvidia 2000 and up: unlinke nvidia-dkms, but 1000 series cards have problems with directx12 games anyway.