### PR TITLE
Add wireless-regdb to packages

### DIFF
--- a/manifest
+++ b/manifest
@@ -156,6 +156,7 @@ export PACKAGES="\
 	wget \
 	which \
 	wireplumber \
+	wireless-regdb \
 	wqy-zenhei \
 	xdg-desktop-portal \
 	xdg-desktop-portal-gnome \


### PR DESCRIPTION
Add wireless-regdb package: this package brings a file in /etc that is fully commented and by default nothing changes from a default configuration.

When a user changes the file /etc/conf.d/wireless-regdom decommenting the regulatory domain more wifi frequencies can be used thus augmenting wifi speed and possible networks to connect to.