### PR TITLE
Neroreflex/ogc

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -103,6 +103,13 @@ pacman --noconfirm -Syy
 sed -i '/BUILDENV/s/ check/ !check/g' /etc/makepkg.conf
 sed -i '/OPTIONS/s/ debug/ !debug/g' /etc/makepkg.conf
 
+# Trust signing keys for the OGC repository
+pacman-key --recv-keys F79100EF8C802DAB81C323BB8EEA5962FE510E19
+pacman-key --lsign-key F79100EF8C802DAB81C323BB8EEA5962FE510E19
+
+echo "[ogc]" >> /etc/pacman.conf
+echo "Server = https://pacman.opengamingcollective.org" >> /etc/pacman.conf
+
 # install kernel package
 if [ "$KERNEL_PACKAGE_ORIGIN" == "repo" ] ; then
 	pacman --noconfirm -S "${KERNEL_PACKAGE}" "${KERNEL_PACKAGE}-headers"

--- a/manifest
+++ b/manifest
@@ -11,7 +11,7 @@ export DOCUMENTATION_URL="https://chimeraos.org/about"
 export BUG_REPORT_URL="https://github.com/ChimeraOS/chimeraos/issues"
 
 export KERNEL_PACKAGE="linux-ogc"
-export KERNEL_PACKAGE_ORIGIN="ghcr.io/opengamingcollective/kernel-packages-arch:latest"
+export KERNEL_PACKAGE_ORIGIN="repo"
 
 export PACKAGES="\
 	accountsservice \

--- a/manifest
+++ b/manifest
@@ -21,6 +21,7 @@ export PACKAGES="\
 	alsa-utils \
 	amd-debug-tools \
 	amd-ucode \
+        asusctl \
 	bash-completion \
 	broadcom-wl-dkms \
 	bzip2 \
@@ -179,7 +180,6 @@ export PACKAGES="\
 # Which is often the same as the package name but it can be different.
 # Check on the AUR webpage if you are unsure
 export AUR_PACKAGES="\
-	asusctl \
 	ayaneo-platform-dkms-git \
 	ayn-platform-dkms-git \
 	bcm20702a1-firmware \


### PR DESCRIPTION
Hi @alkazar we at asus-linux have setup the pacman repo for the kernel, asusctl and cardwire: this PR makes the kernel install from there as well as asusctl cutting the image generation time by quite a bit since it's now precompiled.

I have left out cardwire but is worth considering as it is very useful for mixed iGPU/dGPU laptops.
